### PR TITLE
Back 12 cors fix up

### DIFF
--- a/back/back/settings.py
+++ b/back/back/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "corsheaders.middleware.CorsMiddleware",  # CORS 에러 처리를 위한 미들웨어 추가
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -51,6 +52,33 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
+
+# TODO CORS 설정 nginx 연결 시, 삭제 하기
+# 허용할 메소드
+CORS_ALLOW_METHODS = [
+    "DELETE",
+    "GET",
+    "OPTIONS",
+    "PATCH",
+    "POST",
+    "PUT",
+]
+
+# 허용할 헤더
+CORS_ALLOW_HEADERS = [
+    "accept",
+    "accept-encoding",
+    "authorization",
+    "content-type",
+    "dnt",
+    "origin",
+    "user-agent",
+    "x-csrftoken",
+    "x-requested-with",
+]
+
+# CORS 전체 허용
+CORS_ALLOW_CREDENTIALS = True
 
 ROOT_URLCONF = "back.urls"
 

--- a/back/back/settings.py
+++ b/back/back/settings.py
@@ -56,7 +56,6 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-# TODO CORS 설정 nginx 연결 시, 삭제 하기
 # 허용할 메소드
 CORS_ALLOW_METHODS = [
     "DELETE",
@@ -80,12 +79,10 @@ CORS_ALLOW_HEADERS = [
     "x-requested-with",
 ]
 
-CORS_ALLOWED_ORIGINS = [
-    "http://127.0.0.1:8000",
-    "http://localhost:8000",
-]
-
 # CORS 전체 허용
+CORS_ORIGIN_ALLOW_ALL = True
+
+# 쿠키가 cross-site HTTP 요청에 포함될 수 있도록 허용
 CORS_ALLOW_CREDENTIALS = True
 
 ROOT_URLCONF = "back.urls"

--- a/back/back/settings.py
+++ b/back/back/settings.py
@@ -38,14 +38,17 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    "users",
+    # Third-party apps
+    "corsheaders",
     "rest_framework",
+    # Project apps
+    "users",
 ]
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
-    "corsheaders.middleware.CorsMiddleware",  # CORS 에러 처리를 위한 미들웨어 추가
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "corsheaders.middleware.CorsMiddleware",  # CORS 에러 처리를 위한 미들웨어 추가
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -75,6 +78,11 @@ CORS_ALLOW_HEADERS = [
     "user-agent",
     "x-csrftoken",
     "x-requested-with",
+]
+
+CORS_ALLOWED_ORIGINS = [
+    "http://127.0.0.1:8000",
+    "http://localhost:8000",
 ]
 
 # CORS 전체 허용

--- a/makefile
+++ b/makefile
@@ -17,6 +17,9 @@ fclean:
 linux:
 	docker compose -f ./docker-compose.yml up --build --detach
 
+linux-debug:
+	docker compose -f ./docker-compose.yml up --build
+
 linux-fclean:
 	docker compose -f ./docker-compose.yml down -v
 	docker system prune --all --force --volumes

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ sqlparse==0.4.4
 wheel==0.42.0
 psycopg2-binary==2.9.9
 pillow==10.2.0
+django-cors-headers


### PR DESCRIPTION
### Summary

- CORS 전체 허용
- makefile 명령어 추가


### Describe

- `django-cors-headers` 라는 라이브러리를 사용해서 cors 문제 해결
  - settings.py 에 앱과 기본적인 설정 추가
- makefile에 --detach 옵션을 제거한 `linux-debug` 명령어 추가
