### PR TITLE
[Back 13] save image method overriding

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
-    <data-source source="LOCAL" name="project" uuid="19a21f17-bfab-4a5b-8134-69a94e20f87b">
+    <data-source source="LOCAL" name="tail_passengers@localhost" uuid="dd5d4222-f27f-449d-b19d-334db3bcf391">
       <driver-ref>postgresql</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>org.postgresql.Driver</jdbc-driver>
-      <jdbc-url>jdbc:postgresql://localhost:5432/project</jdbc-url>
+      <jdbc-url>jdbc:postgresql://localhost:5432/tail_passengers</jdbc-url>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
   </component>

--- a/back/back/settings.py
+++ b/back/back/settings.py
@@ -41,9 +41,9 @@ INSTALLED_APPS = [
     # Third-party apps
     "corsheaders",
     "rest_framework",
-    'django.contrib.sites',
-    'rest_framework.authtoken',
-    'allauth',
+    "django.contrib.sites",
+    "rest_framework.authtoken",
+    "allauth",
     # Project apps
     "users",
     "games",
@@ -128,22 +128,13 @@ DATABASES = {
 # DATABASES = {
 #     "default": {
 #         "ENGINE": "django.db.backends.postgresql",
-#         "NAME": "project",
+#         "NAME": "tail_passengers",
 #         "USER": "postgres",
 #         "PASSWORD": "password",
 #         "HOST": "localhost",
 #         "PORT": "",
 #     }
 # }
-
-# sqlite3 for local development
-# DATABASES = {
-#     "default": {
-#         "ENGINE": "django.db.backends.sqlite3",
-#         "NAME": BASE_DIR / "db.sqlite3",
-#     }
-# }
-
 
 # Password validation
 # https://docs.djangoproject.com/en/4.1/ref/settings/#auth-password-validators

--- a/back/users/models.py
+++ b/back/users/models.py
@@ -1,5 +1,7 @@
+import os
 import uuid
 from django.db import models
+from django.conf import settings
 
 
 class UserStatusEnum(models.TextChoices):
@@ -26,6 +28,17 @@ class Users(models.Model):
     class Meta:
         db_table = "Users"
         ordering = ["created_time"]
+
+    def delete(self, using=None, keep_parents=False) -> None:
+        """
+        delete 메서드 오버라이딩
+        Args:
+            using: 삭제할 때 사용할 DB, 기본값은 None으로 기본 DB를 사용
+            keep_parents: 삭제 작업을 수행할 때, 자식 객체를 유지할 지 여부, 기본값은 False로 자식 객체를 삭제
+        """
+        if self.profile_image:
+            os.remove(os.path.join(settings.MEDIA_ROOT, self.profile_image.name))
+        super(Users, self).delete(using, keep_parents)
 
 
 class RequestStatusEnum(models.TextChoices):

--- a/back/users/models.py
+++ b/back/users/models.py
@@ -1,7 +1,5 @@
-import os
 import uuid
 from django.db import models
-from django.conf import settings
 
 
 class UserStatusEnum(models.TextChoices):
@@ -28,17 +26,6 @@ class Users(models.Model):
     class Meta:
         db_table = "Users"
         ordering = ["created_time"]
-
-    def delete(self, using=None, keep_parents=False) -> None:
-        """
-        delete 메서드 오버라이딩
-        Args:
-            using: 삭제할 때 사용할 DB, 기본값은 None으로 기본 DB를 사용
-            keep_parents: 삭제 작업을 수행할 때, 자식 객체를 유지할 지 여부, 기본값은 False로 자식 객체를 삭제
-        """
-        if self.profile_image:
-            os.remove(os.path.join(settings.MEDIA_ROOT, self.profile_image.name))
-        super(Users, self).delete(using, keep_parents)
 
 
 class RequestStatusEnum(models.TextChoices):

--- a/back/users/views.py
+++ b/back/users/views.py
@@ -1,10 +1,12 @@
 import os
 import requests
 import uuid
-from rest_framework import viewsets
+from rest_framework import viewsets, status
+from rest_framework.response import Response
 from rest_framework.views import APIView
 from django.shortcuts import redirect
 from django.core.files.base import ContentFile
+from django.conf import settings
 from dotenv import load_dotenv
 from .serializers import UsersSerializer, FriendRequestSerializer
 from .models import Users, FriendRequests
@@ -13,6 +15,19 @@ from .models import Users, FriendRequests
 class UsersViewSet(viewsets.ModelViewSet):
     queryset = Users.objects.all()
     serializer_class = UsersSerializer
+
+    def destroy(self, request, *args, **kwargs):
+        instance = self.get_object()
+        if instance.profile_image:
+            os.remove(os.path.join(settings.MEDIA_ROOT, instance.profile_image.name))
+        self.perform_destroy(instance)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    def update(self, request, *args, **kwargs):
+        instance = self.get_object()
+        if instance.profile_image:
+            os.remove(os.path.join(settings.MEDIA_ROOT, instance.profile_image.name))
+        return super().update(request, *args, **kwargs)
 
 
 class FriendRequestViewSet(viewsets.ModelViewSet):

--- a/back/users/views.py
+++ b/back/users/views.py
@@ -12,6 +12,7 @@ from .serializers import UsersSerializer, FriendRequestSerializer
 from .models import Users, FriendRequests
 
 
+# https://squirmm.tistory.com/entry/Django-DRF-Method-Override-%EB%B0%A9%EB%B2%95
 class UsersViewSet(viewsets.ModelViewSet):
     queryset = Users.objects.all()
     serializer_class = UsersSerializer

--- a/back/users/views.py
+++ b/back/users/views.py
@@ -4,9 +4,8 @@ import uuid
 from rest_framework import viewsets
 from rest_framework.views import APIView
 from django.shortcuts import redirect
+from django.core.files.base import ContentFile
 from dotenv import load_dotenv
-from .serializers import UsersSerializer
-from .models import Users
 from .serializers import UsersSerializer, FriendRequestSerializer
 from .models import Users, FriendRequests
 
@@ -31,14 +30,15 @@ class Login42APIView(APIView):
 
         oauth_42_api_url = "https://api.intra.42.fr/oauth/authorize"
         return redirect(
-            f'{oauth_42_api_url}?client_id={client_id}&redirect_uri={redirect_uri}&response_type={response_type}&state={state}'
+            f"{oauth_42_api_url}?client_id={client_id}&redirect_uri={redirect_uri}&response_type={response_type}&state={state}"
         )
 
 
+# https://soyoung-new-challenge.tistory.com/92
 class CallbackAPIView(APIView):
     def get(self, request, *args, **kwargs):
         access_token = self._get_access_token(request)
-        #42 api에 정보 요청
+        # 42 api에 정보 요청
         user_info_request = requests.get(
             "https://api.intra.42.fr/v2/me",
             headers={"Authorization": f"Bearer {access_token}"},
@@ -46,25 +46,37 @@ class CallbackAPIView(APIView):
         user_info = user_info_request.json()
         login_id = user_info["login"]
         image_address = user_info["image"]["versions"]["small"]
-        db_request_data = {"intra_id": login_id, "nickname": login_id, "win_count": 0,
-                           "lose_count": 0, "status": 0}  # , "profile_image": image_address}
 
-        # post 요청을 통해 db 업데이트 (프로필 이미지 업로드가 아직 불가)
-        token_request = requests.post("http://127.0.0.1:8000/Users/", db_request_data)
-        return redirect(
-            "http://127.0.0.1:8000/Users/"
+        # image 저장을 위해 post 말고 모델을 생성해서 저장
+        # win, lose는 기본값이 0이므로 따로 저장하지 않음
+        user_instance = Users(
+            intra_id=login_id,
+            nickname=login_id,
+            status=0,
         )
+        response = requests.get(image_address)
+        if response.status_code == 200:
+            image_content = ContentFile(response.content)
+            user_instance.profile_image.save(f"{login_id}.png", image_content)
+        user_instance.save()
+        return redirect("http://127.0.0.1:8000/users/")
 
     def _get_access_token(self, request):
         load_dotenv()
-        grant_type = 'authorization_code'
+        grant_type = "authorization_code"
         client_id = os.environ.get("CLIENT_ID")
         client_secret = os.environ.get("CLIENT_SECRET")
-        code = request.GET.get('code')
-        state = request.GET.get('state')
+        code = request.GET.get("code")
+        state = request.GET.get("state")
         redirect_uri = "http://127.0.0.1:8000/user/42/callback"
-        data = {"grant_type": grant_type, "client_id": client_id, "client_secret": client_secret, "code": code,
-                "state": state, "redirect_uri": redirect_uri}
+        data = {
+            "grant_type": grant_type,
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "code": code,
+            "state": state,
+            "redirect_uri": redirect_uri,
+        }
         token_request = requests.post("https://api.intra.42.fr/oauth/token", data)
         token_response_json = token_request.json()
         return token_response_json.get("access_token")


### PR DESCRIPTION
### Summary

- 42api로 전달된 이미지를 db에 저장
- 이미지 자동 삭제 및 변환을 위해 Users의 delete, put 메소드 오버라이딩

---

### Describe

#### 1. oauth를 통한 user 생성 및 이미지 저장
- 기존: 42api에서 받은 정보들을 직접 post
- 수정: 42api에서 받은 정도로 users 객체를 직접 생성
  - win, lose는 default=0임으로 따로 설정해주지 않아도 됨
  - 불러온 이미지가 정상적이지 않을 경우, 우선 None로 저장함
  - 생성 후, 기존처럼 `/users/` 로 리다이렉트
  - 이미지는 `login_ig.png` 로 저장됨

#### 2. users의 put, delete 메소드 오버라이딩
- DRF는 ModelViewSet에서 기본적으로 메소드들 지원
- 이를 이용해서 put( `update` 함수)와 delete( `destroy` 함수) 메소드를 오버라이딩
- 두 메소드 모두 이미지 값이 None이 아닌지 확인한 후, 삭제
- put은 새로 받은 이미지를 db에 저장한다.

---

### TODO
- 다른 모델들의 메소드들을 오버라이딩 할 경우가 너무나 많음. 이에 대한 정리 필요
  - 게임, 친구 요청과 관련한 url 정리 필요
- 이미지에 null을 허용할 것인가에 대해 확인 필요
- oauth에서 받아오는 정보가 정상적이지 않을 경우에 대한 오류 처리 필요