### PR TITLE
:zap: composite primary key 중복 시, 에러문 출력하도록 변경

### DIFF
--- a/back/games/views.py
+++ b/back/games/views.py
@@ -1,4 +1,6 @@
+from django.db import IntegrityError
 from rest_framework import viewsets
+from rest_framework.exceptions import ValidationError
 from .serializers import (
     GeneralGameLogsSerializer,
     TournamentGameLogsSerializer,
@@ -22,12 +24,30 @@ class JoinGeneralGameViewSet(viewsets.ModelViewSet):
     queryset = JoinGeneralGame.objects.all()
     serializer_class = JoinGeneralGameSerializer
 
+    def create(self, request, *args, **kwargs):
+        try:
+            return super().create(request, *args, **kwargs)
+        except IntegrityError:  # db의 무결성 제약 조건을 위반할 때 발생하는 에러
+            raise ValidationError({"detail": "동일한 게임의 참가자가 이미 존재합니다."})
+
 
 class TournamentGameLogsViewSet(viewsets.ModelViewSet):
     queryset = TournamentGameLogs.objects.all()
     serializer_class = TournamentGameLogsSerializer
 
+    def create(self, request, *args, **kwargs):
+        try:
+            return super().create(request, *args, **kwargs)
+        except IntegrityError:  # db의 무결성 제약 조건을 위반할 때 발생하는 에러
+            raise ValidationError({"detail": "동일한 게임이 이미 존재합니다."})
+
 
 class JoinTournamentGameViewSet(viewsets.ModelViewSet):
     queryset = JoinTournamentGame.objects.all()
     serializer_class = JoinTournamentGameSerializer
+
+    def create(self, request, *args, **kwargs):
+        try:
+            return super().create(request, *args, **kwargs)
+        except IntegrityError:  # db의 무결성 제약 조건을 위반할 때 발생하는 에러
+            raise ValidationError({"detail": "동일한 게임의 참가자가 이미 존재합니다."})


### PR DESCRIPTION
### Summary

- composite primary key가 중복일 때, 500에러를 400에러와 적절한 에러 메세지를 반환하도록 변경했습니다.


### Describe

#### 1. 로그 생성 오버라이딩
- 현재 composite primary key를 중복된 값으로 생성할 때, 에러가 발생하고 서버 에러로 바로 넘어갑니다. 이를 방지하기 위해서 생성 메소드를 오버라이딩했습니다.
- try문과 rest_framework가 제공하는 `ValidationError` 를 사용해서 생성 중 중복 발생으로 에러를 넘길 때, 400에러를 반환하도록 오버라이딩했습니다.
- GeneralGameLogs는 composite primary key가 없기에 따로 오버라이딩하지 않았습니다.
