### PR TITLE
[Back 20] create tests for the game model

### DIFF
--- a/back/accounts/tests.py
+++ b/back/accounts/tests.py
@@ -43,7 +43,7 @@ class UsersViewSetTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
-class UsersDetailViewSetTest(APITestCase):
+class users_detailViewSetTest(APITestCase):
     def setUp(self):
         self.user = get_user_model().objects.create_user(intra_id="3")
         self.other_user = get_user_model().objects.create_user(intra_id="4")
@@ -52,7 +52,7 @@ class UsersDetailViewSetTest(APITestCase):
         """
         권한 없이 delete test
         """
-        url = reverse("usersDetail", kwargs={"pk": self.other_user.pk})
+        url = reverse("users_detail", kwargs={"pk": self.other_user.pk})
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -62,7 +62,7 @@ class UsersDetailViewSetTest(APITestCase):
         """
         self.client.force_authenticate(user=self.user)
         initial_user_count = get_user_model().objects.count()
-        url = reverse("usersDetail", kwargs={"pk": self.user.pk})
+        url = reverse("users_detail", kwargs={"pk": self.user.pk})
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         # 삭제 후 유저 수가 1 감소했는지 확인
@@ -76,7 +76,7 @@ class UsersDetailViewSetTest(APITestCase):
         """
         self.client.force_authenticate(user=self.user)
         initial_user_count = get_user_model().objects.count()
-        url = reverse("usersDetail", kwargs={"pk": self.other_user.pk})
+        url = reverse("users_detail", kwargs={"pk": self.other_user.pk})
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         # 삭제 오류 후 유저 수가 동일한지 확인
@@ -88,7 +88,7 @@ class UsersDetailViewSetTest(APITestCase):
         """
         권한 없이 patch test
         """
-        url = reverse("usersDetail", kwargs={"pk": self.other_user.pk})
+        url = reverse("users_detail", kwargs={"pk": self.other_user.pk})
         response = self.client.patch(url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -97,7 +97,7 @@ class UsersDetailViewSetTest(APITestCase):
         기본적인 patch test
         """
         self.client.force_authenticate(user=self.user)
-        url = reverse("usersDetail", kwargs={"pk": self.user.pk})
+        url = reverse("users_detail", kwargs={"pk": self.user.pk})
         self.assertEqual(self.user.nickname, "3")
         data = {"nickname": "changed"}
         response = self.client.patch(url, data)
@@ -113,7 +113,7 @@ class UsersDetailViewSetTest(APITestCase):
         수정하면 안 되는 필드 테스트
         """
         self.client.force_authenticate(user=self.user)
-        url = reverse("usersDetail", kwargs={"pk": self.user.pk})
+        url = reverse("users_detail", kwargs={"pk": self.user.pk})
         data = {"user_id": "1"}
         response = self.client.patch(url, data)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -123,7 +123,7 @@ class UsersDetailViewSetTest(APITestCase):
         동일한 닉네임으로 변경하는 경우 테스트
         """
         self.client.force_authenticate(user=self.user)
-        url = reverse("usersDetail", kwargs={"pk": self.user.pk})
+        url = reverse("users_detail", kwargs={"pk": self.user.pk})
         data = {"nickname": self.other_user.nickname}
         response = self.client.patch(url, data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/back/accounts/urls.py
+++ b/back/accounts/urls.py
@@ -1,11 +1,6 @@
-from django.urls import include, path
-from rest_framework import routers
+from django.urls import path
 from . import views
 from .views import logout_view
-
-# DefaultRouter
-# router = routers.DefaultRouter()
-# router.register("users", views.UsersViewSet)
 
 urlpatterns = [
     path(
@@ -18,7 +13,7 @@ urlpatterns = [
         views.UsersDetailViewSet.as_view(
             {"get": "list", "patch": "partial_update", "delete": "destroy"}
         ),
-        name="usersDetail",
+        name="users_detail",
     ),
     path("login/", views.Login42APIView.as_view()),
     path("login/42/callback/", views.CallbackAPIView.as_view()),

--- a/back/games/serializers.py
+++ b/back/games/serializers.py
@@ -69,6 +69,20 @@ class TournamentGameLogsSerializer(serializers.ModelSerializer):
             "user_request",
         )
 
+    def validate(self, data):
+        if data["winner"] == data["loser"]:
+            raise serializers.ValidationError("Winner and loser must be different.")
+        # 시작 시간이 끝나는 시간보다 이전인지 확인
+        if data["start_time"] >= data["end_time"]:
+            raise serializers.ValidationError("End time must be later than start time.")
+        # 끝나는 시간이 현재 시각보다 이후인지 확인
+        if data["end_time"] > timezone.now():
+            raise serializers.ValidationError("End time must not be in the future.")
+        # 라운드가 양수인지 확인
+        if data["round"] <= 0:
+            raise serializers.ValidationError("The round must be a positive number.")
+        return data
+
 
 class JoinTournamentGameSerializer(serializers.ModelSerializer):
     user_request = UsersSerializer(read_only=True)

--- a/back/games/tests.py
+++ b/back/games/tests.py
@@ -2,9 +2,14 @@ from django.utils.timezone import make_aware
 from rest_framework.test import APITestCase
 from rest_framework import status
 from django.urls import reverse
-from .models import GeneralGameLogs, JoinGeneralGame
-import pytz
-from datetime import datetime
+from .models import (
+    GeneralGameLogs,
+    JoinGeneralGame,
+    TournamentGameLogs,
+    JoinTournamentGame,
+)
+import uuid
+from datetime import datetime, timedelta
 from accounts.models import Users
 
 
@@ -16,6 +21,8 @@ class GeneralGameLogsViewSetTest(APITestCase):
         # 게임 로그 URL
         self.create_url = reverse("general_game_logs")
         self.list_url = reverse("general_game_logs")
+        self.start_time = make_aware(datetime(2021, 1, 1, 0, 0, 0))
+        self.end_time = make_aware(datetime(2021, 1, 2, 1, 0, 0))
 
     def test_create_general_game_log_without_authenticate(self):
         """
@@ -27,39 +34,333 @@ class GeneralGameLogsViewSetTest(APITestCase):
             "winner": self.user1.user_id,
             "loser": self.user2.user_id,
         }
-        response = self.client.post(self.create_url, data, format="json")
+        response = self.client.post(self.create_url, data)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_create_general_game_log_wit_authenticate(self):
+    def test_create_general_game_log_with_authenticate(self):
         """
         인증이 있을때 201 상태 코드 확인
         """
         self.client.force_authenticate(user=self.user1)
-        tz = pytz.timezone("Asia/Seoul")  # 서울 시간대(UTC+9) 설정
-        start_time = make_aware(datetime(2021, 1, 1, 0, 0, 0), timezone=tz)
-        end_time = make_aware(datetime(2021, 1, 2, 1, 0, 0), timezone=tz)
         winner = self.user1.user_id
         loser = self.user2.user_id
         data = {
-            "start_time": start_time,
-            "end_time": end_time,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
             "winner": winner,
             "loser": loser,
         }
-        response = self.client.post(self.create_url, data, format="json")
+        response = self.client.post(self.create_url, data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # GeneralGameLogs 모델에서 데이터가 잘 들어갔는지 확인
         game_log = GeneralGameLogs.objects.get(game_id=response.data["game_id"])
-        self.assertEqual(game_log.start_time, start_time)
-        self.assertEqual(game_log.end_time, end_time)
+        self.assertEqual(game_log.start_time, self.start_time)
+        self.assertEqual(game_log.end_time, self.end_time)
         self.assertEqual(game_log.winner.user_id, winner)
         self.assertEqual(game_log.loser.user_id, loser)
 
-        # JoinGeneralGame 모델에 게임 로그가 생성 되었는지 확인
+        # JoinGeneralGame 모델에 게임 로그가 생성 하는지 확인
         self.assertTrue(JoinGeneralGame.objects.filter(user_id=self.user1).exists())
+
+        # 생성한 게임 로그의 game_id가 올바른지 확인
         game_log = JoinGeneralGame.objects.get(user_id=self.user1)
-        self.assertEqual(game_log.game_id, response.data["game_id"])
+        self.assertEqual(str(game_log.game_id.game_id), response.data["game_id"])
         self.assertTrue(JoinGeneralGame.objects.filter(user_id=self.user2).exists())
         game_log = JoinGeneralGame.objects.get(user_id=self.user2)
-        self.assertEqual(game_log.game_id, response.data["game_id"])
+        self.assertEqual(str(game_log.game_id.game_id), response.data["game_id"])
+
+    def test_create_general_game_log_same_winner_loser(self):
+        """
+        winner랑 loser가 동일할때 테스트
+        """
+        self.client.force_authenticate(user=self.user1)
+        winner = self.user1.user_id
+        loser = self.user1.user_id
+        data = {
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "winner": winner,
+            "loser": loser,
+        }
+        response = self.client.post(self.create_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_general_game_log_start_time_is_before_the_end_time(self):
+        """
+        시작 시간이 끝나는 시간보다 이전인지 확인하는 테스트
+        """
+        self.client.force_authenticate(user=self.user1)
+        winner = self.user1.user_id
+        loser = self.user2.user_id
+        data = {
+            "start_time": self.end_time,
+            "end_time": self.start_time,
+            "winner": winner,
+            "loser": loser,
+        }
+        response = self.client.post(self.create_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_general_game_log_end_time_is_before_future(self):
+        """
+        끝나는 시간이 미래보다 전인지 확인하는 테스트
+        """
+        self.client.force_authenticate(user=self.user1)
+        winner = self.user1.user_id
+        loser = self.user2.user_id
+
+        data = {
+            "start_time": self.end_time,
+            "end_time": datetime.now() + timedelta(hours=2),
+            "winner": winner,
+            "loser": loser,
+        }
+        response = self.client.post(self.create_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_get_general_game_log_uuid_fk(self):
+        """
+        get으로 create한 general_game_log/<uuid:fk>/ 잘 가져오는지 확인하는 테스트
+        """
+        self.client.force_authenticate(user=self.user1)
+        winner = self.user1.user_id
+        loser = self.user2.user_id
+        data = {
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "winner": winner,
+            "loser": loser,
+        }
+        response = self.client.post(self.create_url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # get 으로 요청
+        response = self.client.get(
+            reverse("general_game_logs_detail", kwargs={"fk": self.user1.user_id})
+        )
+
+        # get 데이터 확인
+        self.assertEqual(response.data[0]["start_time"], self.start_time.isoformat())
+        self.assertEqual(response.data[0]["end_time"], self.end_time.isoformat())
+        self.assertEqual(response.data[0]["winner"], winner)
+        self.assertEqual(response.data[0]["loser"], loser)
+
+
+class TournamentGameLogsViewSetTest(APITestCase):
+    def setUp(self):
+        # 네 명의 사용자 생성
+        self.user1 = Users.objects.create_user(intra_id="user1")
+        self.user2 = Users.objects.create_user(intra_id="user2")
+        self.user3 = Users.objects.create_user(intra_id="user3")
+        self.user4 = Users.objects.create_user(intra_id="user4")
+        # 토너먼트 로그 URL
+        self.tournament_name = "test"
+        self.create_log = reverse("create_tournament_game_logs")
+        self.start_time = make_aware(datetime(2021, 1, 1, 0, 0, 0))
+        self.end_time = make_aware(datetime(2021, 1, 2, 1, 0, 0))
+
+    def test_create_tournament_game_log_without_authenticate(self):
+        """
+        인증이 없을때 403 에러 확인
+        """
+        data = {
+            "tournament_name": self.tournament_name,
+            "round": 1,
+            "winner": self.user1.user_id,
+            "loser": self.user2.user_id,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "is_final": False,
+        }
+
+        response = self.client.post(self.create_log, data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_create_tournament_game_log(self):
+        """
+        토너먼트 생성 확인
+        """
+        self.client.force_authenticate(user=self.user1)
+        data = {
+            "tournament_name": self.tournament_name,
+            "round": 1,
+            "winner": self.user1.user_id,
+            "loser": self.user2.user_id,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "is_final": False,
+        }
+
+        response = self.client.post(self.create_log, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # TournamentGameLogs 모델에서 데이터가 잘 들어갔는지 확인
+        game_log = TournamentGameLogs.objects.get(
+            tournament_name=response.data["tournament_name"]
+        )
+        self.assertEqual(game_log.tournament_name, self.tournament_name)
+        self.assertEqual(game_log.round, 1)
+        self.assertEqual(game_log.winner.user_id, self.user1.user_id)
+        self.assertEqual(game_log.loser.user_id, self.user2.user_id)
+        self.assertEqual(game_log.start_time, self.start_time)
+        self.assertEqual(game_log.end_time, self.end_time)
+        self.assertEqual(game_log.is_final, False)
+
+        # JoinTournamentGame 모델에 게임 로그가 생성 하는지 확인
+        self.assertTrue(JoinTournamentGame.objects.filter(user_id=self.user1).exists())
+        # 생성한 게임 로그의 torunament_name이 올바른지 확인
+        game_log = JoinTournamentGame.objects.get(user_id=self.user1)
+        self.assertEqual(
+            str(game_log.game_id.tournament_name), response.data["tournament_name"]
+        )
+        self.assertTrue(JoinTournamentGame.objects.filter(user_id=self.user2).exists())
+        game_log = JoinTournamentGame.objects.get(user_id=self.user2)
+        self.assertEqual(
+            str(game_log.game_id.tournament_name), response.data["tournament_name"]
+        )
+
+    def test_create_tournament_game_log_same_winner_loser(self):
+        """
+        winner랑 loser가 같을때 테스트
+        """
+        self.client.force_authenticate(user=self.user1)
+        data = {
+            "tournament_name": self.tournament_name,
+            "round": 1,
+            "winner": self.user1.user_id,
+            "loser": self.user1.user_id,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "is_final": False,
+        }
+
+        response = self.client.post(self.create_log, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_tournament_multi_game_log(self):
+        """
+        토너먼트 여러개 생성 확인 테스트
+        """
+        self.client.force_authenticate(user=self.user1)
+        data = {
+            "tournament_name": self.tournament_name,
+            "round": 1,
+            "winner": self.user1.user_id,
+            "loser": self.user2.user_id,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "is_final": False,
+        }
+
+        response = self.client.post(self.create_log, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data2 = {
+            "tournament_name": self.tournament_name,
+            "round": 2,
+            "winner": self.user3.user_id,
+            "loser": self.user4.user_id,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "is_final": False,
+        }
+
+        response = self.client.post(self.create_log, data2)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data3 = {
+            "tournament_name": self.tournament_name,
+            "round": 3,
+            "winner": self.user3.user_id,
+            "loser": self.user1.user_id,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "is_final": True,
+        }
+        response = self.client.post(self.create_log, data3)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_create_tournament_game_log_tournament_name_and_round_is_unique(self):
+        """
+        토너먼트 이름과 라운드 조합은 유일한가 테스트
+        """
+        self.client.force_authenticate(user=self.user1)
+        data = {
+            "tournament_name": self.tournament_name,
+            "round": 1,
+            "winner": self.user1.user_id,
+            "loser": self.user2.user_id,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "is_final": False,
+        }
+
+        response = self.client.post(self.create_log, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data2 = {
+            "tournament_name": self.tournament_name,
+            "round": 1,
+            "winner": self.user3.user_id,
+            "loser": self.user4.user_id,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "is_final": False,
+        }
+
+        response = self.client.post(self.create_log, data2)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_get_tournament_game_log_with_tournament_name(self):
+        """
+        tournament_name 조회 및 uuid로 조회가 잘 되는지 테스트
+        """
+        self.client.force_authenticate(user=self.user1)
+        data = {
+            "tournament_name": self.tournament_name,
+            "round": 1,
+            "winner": self.user1.user_id,
+            "loser": self.user2.user_id,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "is_final": False,
+        }
+
+        response = self.client.post(self.create_log, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data2 = {
+            "tournament_name": self.tournament_name,
+            "round": 2,
+            "winner": self.user3.user_id,
+            "loser": self.user4.user_id,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "is_final": False,
+        }
+
+        response = self.client.post(self.create_log, data2)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data3 = {
+            "tournament_name": self.tournament_name,
+            "round": 3,
+            "winner": self.user3.user_id,
+            "loser": self.user1.user_id,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "is_final": True,
+        }
+        response = self.client.post(self.create_log, data3)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        response = self.client.get(
+            reverse("tournament_name_logs", kwargs={"name": self.tournament_name})
+        )
+        assert len(response.data) == 3
+        self.assertEqual(self.user1.user_id, response.data[0]["winner"])
+        self.assertEqual(self.user3.user_id, response.data[1]["winner"])
+        self.assertEqual(self.user3.user_id, response.data[2]["winner"])
+
+        response = self.client.get(
+            reverse("tournament_game_user_logs", kwargs={"fk": self.user1.user_id})
+        )
+        assert len(response.data) == 2
+        self.assertEqual(1, response.data[0]["round"])
+        self.assertEqual(3, response.data[1]["round"])

--- a/back/games/urls.py
+++ b/back/games/urls.py
@@ -1,15 +1,6 @@
-from django.urls import include, path
-from rest_framework import routers
+from django.urls import path
 from . import views
 
-
-# DefaultRouter
-router = routers.DefaultRouter()
-router.register("general_game_logs", views.GeneralGameLogsViewSet)
-router.register("tournament_game_logs", views.TournamentGameLogsViewSet)
-# API 지원 안 함
-# router.register("join_general_game", views.JoinGeneralGameViewSet)
-# router.register("join_tournament_game", views.JoinTournamentGameViewSet)
 
 urlpatterns = [
     path(
@@ -20,14 +11,21 @@ urlpatterns = [
     path(
         "general_game_logs/<uuid:fk>/",
         views.GeneralGameLogsViewSet.as_view({"get": "list"}),
+        name="general_game_logs_detail",
+    ),
+    path(
+        "tournament_game_logs/",
+        views.TournamentGameLogsViewSet.as_view({"post": "create"}),
+        name="create_tournament_game_logs",
     ),
     path(
         "tournament_game_logs/<uuid:fk>/",
         views.TournamentGameLogsViewSet.as_view({"get": "list"}),
+        name="tournament_game_user_logs",
     ),
     path(
         "tournament_game_logs/<str:name>/",
         views.TournamentGameLogsViewSet.as_view({"get": "list"}),
+        name="tournament_name_logs",
     ),
-    path("", include(router.urls)),
 ]


### PR DESCRIPTION
### Summary
- games 모델에 대한 유효성 로직 추가했습니다.
- games 테스트 생성 및 추가했습니다.
- games 모델 생성할때 관련된 join 모델 생성 및 유효성 검사 로직 추가
- accounts url 관련 name 수정했습니다.
### Describe
#### games 모델에 대한 유효성 로직 추가했습니다.
- back/games/serializers.py안에 유효성 로직(winner, loser가 다른지, start_time, end_time 관련)를 추가했습니다.
#### games 테스트 생성 및 추가했습니다.
- 기본적인 게임 모델 생성, 생성한 데이터가 올바른지, 간단한 예외 케이스를 추가했습니다. 
#### games 모델 생성할때 관련된 join 모델 생성 및 유효성 검사 로직 추가
- 일반 게임, 토너먼트 게임 모델을 생성할때 관련된 join 모델을 생성하도록 로직을 추가했습니다.
#### accounts url 관련 name 수정했습니다.
- camelcase에서 snakecase로 수정했습니다.
### TODO
- 추가한 테스트는 간단한 로직을 테스트 한것입니다.
- 지금 현재로는 1라운드에서 패한 사람이 3라운드에 참여하거나, 1라운드에 참가한 사람이 2라운드에 참가하는등의 로직은 걸러내지 못합니다.
- 여기서 걸러내는게 맞는지 고민이며 나중에 게임 로직에서 걸러내는게 맞지 않을지 고민이 있습니다.