### PR TITLE
[Back-21] make friend requests uri

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -8,5 +8,17 @@
       <jdbc-url>jdbc:postgresql://localhost:5432/tail_passengers</jdbc-url>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
+    <data-source source="LOCAL" name="db" uuid="3b3c24ee-c47e-4581-9350-3bfedf1b8078">
+      <driver-ref>sqlite.xerial</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>org.sqlite.JDBC</jdbc-driver>
+      <jdbc-url>jdbc:sqlite:$PROJECT_DIR$/back/db.sqlite3</jdbc-url>
+      <working-dir>$ProjectFileDir$</working-dir>
+      <libraries>
+        <library>
+          <url>file://$APPLICATION_CONFIG_DIR$/jdbc-drivers/Xerial SQLiteJDBC/3.43.0/org/xerial/sqlite-jdbc/3.43.0.0/sqlite-jdbc-3.43.0.0.jar</url>
+        </library>
+      </libraries>
+    </data-source>
   </component>
 </project>

--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectTasksOptions">
-    <TaskOptions isEnabled="false">
-      <option name="arguments" value="" />
+    <TaskOptions isEnabled="true">
+      <option name="arguments" value="$FilePath$" />
       <option name="checkSyntaxErrors" value="true" />
       <option name="description" />
       <option name="exitCodeBehavior" value="ERROR" />
       <option name="fileExtension" value="py" />
-      <option name="immediateSync" value="true" />
+      <option name="immediateSync" value="false" />
       <option name="name" value="black" />
-      <option name="output" value="" />
+      <option name="output" value="$FilePath$" />
       <option name="outputFilters">
         <array />
       </option>
       <option name="outputFromStdout" value="false" />
-      <option name="program" value="$PROJECT_DIR$/../Library/Python/3.11/lib/python/site-packages/black" />
+      <option name="program" value="$PROJECT_DIR$/venv/bin/black" />
       <option name="runOnExternalChanges" value="false" />
       <option name="scopeName" value="Project Files" />
       <option name="trackOnlyRoot" value="false" />
-      <option name="workingDir" value="" />
+      <option name="workingDir" value="$ProjectFileDir$" />
       <envs />
     </TaskOptions>
   </component>

--- a/back/accounts/views.py
+++ b/back/accounts/views.py
@@ -16,7 +16,6 @@ from rest_framework.exceptions import ValidationError, PermissionDenied
 from django.contrib.auth import logout
 
 
-
 # https://squirmm.tistory.com/entry/Django-DRF-Method-Override-%EB%B0%A9%EB%B2%95
 class UsersViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]

--- a/back/friendrequests/serializers.py
+++ b/back/friendrequests/serializers.py
@@ -24,6 +24,7 @@ class FriendRequestSerializer(serializers.ModelSerializer):
     class Meta:
         model = FriendRequests
         fields = (
+            "request_id",
             "request_user_id",
             "response_user_id",
             "friend_request",
@@ -36,7 +37,6 @@ class FriendRequestDetailSerializer(serializers.ModelSerializer):
     class Meta:
         model = FriendRequests
         fields = (
-            "request_id",
             "status",
             "friend_request",
         )

--- a/back/friendrequests/serializers.py
+++ b/back/friendrequests/serializers.py
@@ -10,6 +10,7 @@ class FriendListSerializer(serializers.ModelSerializer):
     class Meta:
         model = FriendRequests
         fields = (
+            "request_id",
             "request_user_id",
             "response_user_id",
             "status",
@@ -25,5 +26,17 @@ class FriendRequestSerializer(serializers.ModelSerializer):
         fields = (
             "request_user_id",
             "response_user_id",
+            "friend_request",
+        )
+
+
+class FriendRequestDetailSerializer(serializers.ModelSerializer):
+    friend_request = UsersSerializer(read_only=True)
+
+    class Meta:
+        model = FriendRequests
+        fields = (
+            "request_id",
+            "status",
             "friend_request",
         )

--- a/back/friendrequests/urls.py
+++ b/back/friendrequests/urls.py
@@ -3,31 +3,24 @@ from . import views
 
 urlpatterns = [
     path(
-        "friend_requests/<uuid:user_id>/",
+        "friend_requests/<uuid:user_id>/<str:status>/",
         views.FriendListViewSet.as_view({"get": "list"}),
     ),
     path(
-        "friend_requests/<uuid:user_id>/<uuid:request_id>/",
+        "friend_requests/<uuid:request_id>/",
         views.FriendRequestDetailViewSet.as_view(
             {
-                "get": "list",
                 "patch": "partial_update",
                 "delete": "destroy",
             }
         ),
     ),
     path(
-        "friend_requests/<uuid:user_id>/<str:status>/",
-        views.FriendListViewSet.as_view({"get": "list"}),
-    ),
-    path(
         "friend_requests/",
         views.FriendRequestViewSet.as_view(
             {
-                "get": "list",
                 "post": "create",
             }
         ),
     ),
-    # path("", views.FriendRequestViewSet.as_view({"get": "list"})),
 ]

--- a/back/friendrequests/urls.py
+++ b/back/friendrequests/urls.py
@@ -1,19 +1,33 @@
-from django.urls import include, path
-from rest_framework import routers
+from django.urls import path
 from . import views
-
-# DefaultRouter
-router = routers.DefaultRouter()
-router.register("friend_requests", views.FriendRequestViewSet)
 
 urlpatterns = [
     path(
-        "friend_requests/<uuid:user_id>",
+        "friend_requests/<uuid:user_id>/",
+        views.FriendListViewSet.as_view({"get": "list"}),
+    ),
+    path(
+        "friend_requests/<uuid:user_id>/<uuid:request_id>/",
+        views.FriendRequestDetailViewSet.as_view(
+            {
+                "get": "list",
+                "patch": "partial_update",
+                "delete": "destroy",
+            }
+        ),
+    ),
+    path(
+        "friend_requests/<uuid:user_id>/<str:status>/",
         views.FriendListViewSet.as_view({"get": "list"}),
     ),
     path(
         "friend_requests/",
-        views.FriendRequestViewSet.as_view({"get": "list", "post": "create"}),
+        views.FriendRequestViewSet.as_view(
+            {
+                "get": "list",
+                "post": "create",
+            }
+        ),
     ),
-    path("", include(router.urls)),
+    # path("", views.FriendRequestViewSet.as_view({"get": "list"})),
 ]

--- a/back/friendrequests/views.py
+++ b/back/friendrequests/views.py
@@ -25,8 +25,7 @@ class FriendListViewSet(viewsets.ModelViewSet):
         status = kwargs["status"]
         if status == "pending":
             queryset = self.queryset.filter(
-                Q(Q(request_user_id=user_id) | Q(response_user_id=user_id))
-                & Q(status="0")
+                Q(response_user_id=user_id) & Q(status="pending")
             )
         elif status == "accepted":
             queryset = self.queryset.filter(

--- a/back/friendrequests/views.py
+++ b/back/friendrequests/views.py
@@ -4,7 +4,11 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from .models import FriendRequests
-from .serializers import FriendListSerializer, FriendRequestSerializer
+from .serializers import (
+    FriendListSerializer,
+    FriendRequestSerializer,
+    FriendRequestDetailSerializer,
+)
 
 
 class FriendListViewSet(viewsets.ModelViewSet):
@@ -14,14 +18,23 @@ class FriendListViewSet(viewsets.ModelViewSet):
     http_method_names = ["get"]
 
     def list(self, request, *args, **kwargs):
-        # 밑에 if문은 debug를 위한 임시 get
-        if "user_id" not in kwargs:
-            return super().list(request, *args, **kwargs)
-
         user_id = kwargs["user_id"]
         queryset = self.queryset.filter(
             Q(request_user_id=user_id) | Q(response_user_id=user_id)
         )
+
+        if "status" in kwargs:
+            status = kwargs["status"]
+            if status == "pending":
+                queryset = self.queryset.filter(
+                    Q(Q(request_user_id=user_id) | Q(response_user_id=user_id))
+                    & Q(status="0")
+                )
+            elif status == "accepted":
+                queryset = self.queryset.filter(
+                    Q(Q(request_user_id=user_id) | Q(response_user_id=user_id))
+                    & Q(status="1")
+                )
         serializer = self.serializer_class(queryset, many=True)
         return Response(serializer.data)
 
@@ -30,19 +43,22 @@ class FriendRequestViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
     queryset = FriendRequests.objects.all()
     serializer_class = FriendRequestSerializer
-    http_method_names = ["post", "get"]  # TODO debug를 위해 get 임시 추가
+    http_method_names = [
+        "post",
+        "patch",
+        "delete",
+        "get",
+    ]  # TODO debug를 위해 get 임시 추가
+    lookup_field = "request_id"
 
     def create(self, request, *args, **kwargs):
         request_user_id = request.data.get("request_user_id")
         response_user_id = request.data.get("response_user_id")
-        instance = self.get_object()
-        if instance.user_id != request_user_id and instance.user_id != response_user_id:
+        # TODO 친구 요청하는 것이 자기 자신인지 확인하는 로직 추가
+        if request_user_id == response_user_id:
             raise ValidationError(
-                {"detail": "다른 사용자의 정보를 사용할 수 없습니다."}
+                {"detail": "친구 요청을 받는 사람은 자신이 될 수 없습니다."}
             )
-        elif request_user_id == response_user_id:
-            return ValidationError({"detail": "자신에게 친구 요청을 보낼 수 없습니다."})
-
         queryset = self.queryset.filter(
             Q(Q(request_user_id=request_user_id) & Q(response_user_id=response_user_id))
             | Q(
@@ -51,5 +67,34 @@ class FriendRequestViewSet(viewsets.ModelViewSet):
             )
         )
         if queryset.exists():
-            return ValidationError({"detail": "이미 친구 요청을 보냈습니다."})
+            raise ValidationError({"detail": "이미 친구 요청을 보냈습니다."})
         return super().create(request, *args, **kwargs)
+
+
+class FriendRequestDetailViewSet(viewsets.ModelViewSet):
+    permission_classes = [IsAuthenticated]
+    queryset = FriendRequests.objects.all()
+    serializer_class = FriendRequestDetailSerializer
+    http_method_names = ["get", "patch", "delete"]
+    lookup_field = "request_id"
+
+    def partial_update(self, request, *args, **kwargs):
+        user_id = kwargs["user_id"]
+        instance = self.get_object()
+        response_user_id = instance.response_user_id.user_id
+        if response_user_id != user_id:
+            raise ValidationError(
+                {"detail": "자신이 아닌 다른 사람의 친구 요청을 거절할 수 없습니다."}
+            )
+        return super().partial_update(request, *args, **kwargs)
+
+    def destroy(self, request, *args, **kwargs):
+        user_id = kwargs["user_id"]
+        instance = self.get_object()
+        response_user_id = instance.response_user_id.user_id
+        request_user_id = instance.request_user_id.user_id
+        if response_user_id != user_id and request_user_id != user_id:
+            raise ValidationError(
+                {"detail": "자신이 아닌 다른 사람의 친구 요청을 삭제할 수 없습니다."}
+            )
+        return super().destroy(request, *args, **kwargs)


### PR DESCRIPTION
### Summary

- friend_requsts/ url 구현했습니다.


### Describe

#### 1. lookup_field 관련 에러 발생
- DRF가 delete, patch 메소드에서 url에 pk나 pk 역할을 할 수 있는 것을 요구했지만 기존 url엔 그런 정보가 없기에 에러를 발생시켰습니다.
- 이를 body나 lookup_field를 비활성화하는 방법으로 찾아보았으나 DRF에서 지원하지 않는 것으로 확인되어 url을 수정했습니다.

#### 2. URL을 수정
- request.user에 request를 보낸 유저의 정보가 있음을 확인했습니다.
- 위 방법을 바탕으로 아래와 같이 url을 수정하고 권한을 주었습니다.

- /friend_requests/<uuid:request_id>/
  - 허용 메소드: PATCH, DELETE
  - 권한
    - PATCH: 요청 받은 유저
    - DELETE: 요청한 유저, 요청 받은 유저
- /friend_requests/<uuid:user_id>/<str:status>/
  - 허용 메소드: GET
  - 권한
    - GET: login한 모든 유저 
- /friend_requests/
  - 허용 메소드: POST
  - 권한
    - POST: 요청하는 유저 == 로그인한 유저 
