### PR TITLE
[Back-23] connect django and swagger

### DIFF
--- a/back/back/settings.py
+++ b/back/back/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     # Third-party apps
     "corsheaders",
+    "drf_yasg",
     "rest_framework",
     "rest_framework.authtoken",
     "allauth",
@@ -123,24 +124,24 @@ WSGI_APPLICATION = "back.wsgi.application"
 #     }
 # }
 # sqlite3 for test
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    }
-}
-
-# postgresql for local development
 # DATABASES = {
 #     "default": {
-#         "ENGINE": "django.db.backends.postgresql",
-#         "NAME": "tail_passengers",
-#         "USER": "postgres",
-#         "PASSWORD": "password",
-#         "HOST": "localhost",
-#         "PORT": "",
+#         "ENGINE": "django.db.backends.sqlite3",
+#         "NAME": BASE_DIR / "db.sqlite3",
 #     }
 # }
+
+# postgresql for local development
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": "tail_passengers",
+        "USER": "postgres",
+        "PASSWORD": "password",
+        "HOST": "localhost",
+        "PORT": "",
+    }
+}
 
 # Password validation
 # https://docs.djangoproject.com/en/4.1/ref/settings/#auth-password-validators

--- a/back/back/settings.py
+++ b/back/back/settings.py
@@ -124,24 +124,24 @@ WSGI_APPLICATION = "back.wsgi.application"
 #     }
 # }
 # sqlite3 for test
-# DATABASES = {
-#     "default": {
-#         "ENGINE": "django.db.backends.sqlite3",
-#         "NAME": BASE_DIR / "db.sqlite3",
-#     }
-# }
-
-# postgresql for local development
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.postgresql",
-        "NAME": "tail_passengers",
-        "USER": "postgres",
-        "PASSWORD": "password",
-        "HOST": "localhost",
-        "PORT": "",
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
     }
 }
+
+# postgresql for local development
+# DATABASES = {
+#     "default": {
+#         "ENGINE": "django.db.backends.postgresql",
+#         "NAME": "tail_passengers",
+#         "USER": "postgres",
+#         "PASSWORD": "password",
+#         "HOST": "localhost",
+#         "PORT": "",
+#     }
+# }
 
 # Password validation
 # https://docs.djangoproject.com/en/4.1/ref/settings/#auth-password-validators

--- a/back/back/urls.py
+++ b/back/back/urls.py
@@ -1,9 +1,40 @@
-from django.urls import path, include
+from django.urls import path, include, re_path
 from django.conf import settings
 from django.conf.urls.static import static
+from drf_yasg import openapi
+from drf_yasg.views import get_schema_view
+from rest_framework.permissions import AllowAny
+
+schema_view_v1 = get_schema_view(
+    openapi.Info(
+        title="제목",
+        default_version="v1",
+        description="설명",
+        terms_of_service="https://www.google.com/policies/terms/",
+    ),
+    public=True,
+    permission_classes=[
+        AllowAny,
+    ],
+)
 
 urlpatterns = [
     path("", include("games.urls")),
     path("", include("accounts.urls")),
     path("", include("friendrequests.urls")),
+    re_path(
+        r"^swagger(?P<format>\.json|\.yaml)$",
+        schema_view_v1.without_ui(cache_timeout=0),
+        name="schema-json",
+    ),
+    re_path(
+        r"^swagger/$",
+        schema_view_v1.with_ui("swagger", cache_timeout=0),
+        name="schema-swagger-ui",
+    ),
+    re_path(
+        r"^redoc/$",
+        schema_view_v1.with_ui("redoc", cache_timeout=0),
+        name="schema-redoc",
+    ),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ django-allauth
 dj-rest-auth
 python-dotenv
 django-cors-headers
+drf-yasg


### PR DESCRIPTION
### Summary

- swagger, redoc를 이용해 api 명세를 자동으로 볼 수 있도록 추가했습니다.


### Describe

- drf-yasg 라이브러리를 설치해서 swagger를 연동했습니다.
- url 관련 로직은 간단하게 swagger 형식의 스키마를 보내는 동작을 추가한 것입니다.
- http://localhost:8000/swagger : api 명세를 swagger로
- http://localhost:8000/redoc : api 명세를 redoc으로