### PR TITLE
[Back-22] update oauth env settings

### DIFF
--- a/back/accounts/tests.py
+++ b/back/accounts/tests.py
@@ -43,7 +43,7 @@ class UsersViewSetTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
-class users_detailViewSetTest(APITestCase):
+class UsersDetailViewSetTest(APITestCase):
     def setUp(self):
         self.user = get_user_model().objects.create_user(intra_id="3")
         self.other_user = get_user_model().objects.create_user(intra_id="4")

--- a/back/accounts/views.py
+++ b/back/accounts/views.py
@@ -71,6 +71,14 @@ class UsersDetailViewSet(viewsets.ModelViewSet):
         "user_permissions",
     )
 
+    def list(self, request, *args, **kwargs):
+        """
+        GET method override
+        """
+        queryset = Users.objects.filter(pk=kwargs["pk"])
+        serializer = UsersDetailSerializer(queryset, many=True)
+        return Response(serializer.data)
+
     def destroy(self, request, *args, **kwargs):
         """
         DELETE method override
@@ -120,12 +128,12 @@ class Login42APIView(APIView):
         client_id = os.environ.get("CLIENT_ID")
         response_type = "code"
         redirect_uri = os.environ.get("REDIRECT_URI")
-        state = str(uuid.uuid4())
-        request.session["state"] = state
+        state = os.environ.get("STATE")
         oauth_42_api_url = "https://api.intra.42.fr/oauth/authorize"
         return redirect(
             f"{oauth_42_api_url}?client_id={client_id}&redirect_uri={redirect_uri}&response_type={response_type}&state={state}"
         )
+
 
 
 # https://soyoung-new-challenge.tistory.com/92
@@ -136,7 +144,7 @@ class CallbackAPIView(APIView):
 
         if (
             request.session.get("state")
-            and not request.GET.get("state") == request.session["state"]
+            and not request.GET.get("state") == os.environ.get("STATE")
         ):
             raise ValidationError({"detail": "oauth중 state 검증 실패."})
 


### PR DESCRIPTION
### Summary
- oauth 관련 수정했습니다.
- users/<uuid:pk>/의 view 수정했습니다.
### Describe
#### oauth 관련 수정했습니다.
- 원래 oauth에서 state를 검증하는 로직이 있었습니다 (state를 back에서 랜덤으로 생성한 뒤 session에 저장, 이후 비교하는 로직)
- 하지만 프론트랑 합치는 중에 cors에러가 발생했습니다.
- 해결법으로 https://api.intra.42.fr/oauth/authorize redirect하는 곳을 프론트로 옮겼습니다.
- 즉, 프론트에서도 state가 필요해서 state를 랜덤으로 생성한 뒤 .env파일로 옮겼습니다.
#### users/<uuid:pk>/의 view 수정했습니다.
- users/uuid:pk/ 가 들어오면 pk에 맞는 users의 상세 정보가 나오도록 수정했습니다.

