### PR TITLE
[Back-24] add test for friend request

### DIFF
--- a/.idea/backend.iml
+++ b/.idea/backend.iml
@@ -16,7 +16,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.11 (backend)" jdkType="Python SDK" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,5 +5,5 @@
     <option name="enabledOnSave" value="true" />
     <option name="sdkName" value="Python 3.12 (backend)" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11 (backend)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.12 (backend)" project-jdk-type="Python SDK" />
 </project>

--- a/back/friendrequests/models.py
+++ b/back/friendrequests/models.py
@@ -6,7 +6,6 @@ from django.db import models
 class RequestStatusEnum(models.TextChoices):
     ACCEPTED = "1", "Accept"
     PENDING = "0", "Pending"
-    REJECTED = "-1", "Reject"
 
 
 """

--- a/back/friendrequests/tests.py
+++ b/back/friendrequests/tests.py
@@ -1,3 +1,71 @@
-from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+from .models import FriendRequests
+from accounts.models import Users
 
-# Create your tests here.
+
+class FriendListViewSetTestCase(APITestCase):
+    def setUp(self):
+        # 사용자 생성
+        self.user1 = Users.objects.create_user(intra_id="user1")
+        self.user2 = Users.objects.create_user(intra_id="user2")
+        self.user3 = Users.objects.create_user(intra_id="user3")
+
+        # 친구 요청 생성
+        FriendRequests.objects.create(
+            request_user_id=self.user1,
+            response_user_id=self.user2,
+            status="0",
+        )
+        FriendRequests.objects.create(
+            request_user_id=self.user1,
+            response_user_id=self.user3,
+            status="1",
+        )
+
+    def test_get_list_all_without_authenticate(self):
+        """
+        인증 없이 친구 요청 리스트 확인 시, 403 에러 확인
+        """
+        url = reverse(
+            "friend_list", kwargs={"user_id": self.user1.user_id, "status": "all"}
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_get_list_all(self):
+        """
+        전체 친구 요청 리스트 확인
+        """
+        self.client.force_authenticate(user=self.user1)
+        url = reverse(
+            "friend_list", kwargs={"user_id": self.user1.user_id, "status": "all"}
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+
+    def test_get_list_pending(self):
+        """
+        pending 친구 요청 리스트 확인
+        """
+        self.client.force_authenticate(user=self.user1)
+        url = reverse(
+            "friend_list", kwargs={"user_id": self.user1.user_id, "status": "pending"}
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+
+    def test_get_list_accepted(self):
+        """
+        accepted 친구 요청 리스트 확인
+        """
+        self.client.force_authenticate(user=self.user1)
+        url = reverse(
+            "friend_list", kwargs={"user_id": self.user1.user_id, "status": "accepted"}
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)

--- a/back/friendrequests/tests.py
+++ b/back/friendrequests/tests.py
@@ -329,8 +329,7 @@ class FriendRequestDetailViewSetTestCase(APITestCase):
             "friend_requests_detail",
             kwargs={"request_id": self.friend_request2.request_id},
         )
-        data = {"status": "invalid"}
-        response = self.client.delete(url, data)
+        response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_delete_friend_request_another_user(self):

--- a/back/friendrequests/tests.py
+++ b/back/friendrequests/tests.py
@@ -6,6 +6,11 @@ from accounts.models import Users
 
 
 class FriendListViewSetTestCase(APITestCase):
+    """
+    FriendListViewSet 테스트
+    - method: GET
+    """
+
     def setUp(self):
         # 사용자 생성
         self.user1 = Users.objects.create_user(intra_id="user1")
@@ -52,7 +57,7 @@ class FriendListViewSetTestCase(APITestCase):
         """
         self.client.force_authenticate(user=self.user1)
         url = reverse(
-            "friend_list", kwargs={"user_id": self.user1.user_id, "status": "pending"}
+            "friend_list", kwargs={"user_id": self.user2.user_id, "status": "pending"}
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -69,3 +74,273 @@ class FriendListViewSetTestCase(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 1)
+
+    def test_get_list_invalid_status(self):
+        """
+        잘못된 status로 요청 시, 400 에러 확인
+        """
+        self.client.force_authenticate(user=self.user1)
+        url = reverse(
+            "friend_list", kwargs={"user_id": self.user1.user_id, "status": "invalid"}
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class FriendRequestViewSetTestCase(APITestCase):
+    """
+    FriendRequestViewSet 테스트
+    - method: POST
+    """
+
+    def setUp(self):
+        # url
+        self.url = reverse("friend_requests")
+
+        # 사용자 생성
+        self.user1 = Users.objects.create_user(intra_id="user1")
+        self.user2 = Users.objects.create_user(intra_id="user2")
+        self.user3 = Users.objects.create_user(intra_id="user3")
+        self.user4 = Users.objects.create_user(intra_id="user4")
+
+        # 친구 요청 생성
+        FriendRequests.objects.create(
+            request_user_id=self.user2,
+            response_user_id=self.user3,
+            status="0",
+        )
+        FriendRequests.objects.create(
+            request_user_id=self.user3,
+            response_user_id=self.user4,
+            status="1",
+        )
+
+    def test_create_friend_request_without_authenticate(self):
+        """
+        인증 없이 친구 요청 생성 시, 403 에러 확인
+        """
+        data = {
+            "request_user_id": self.user1.user_id,
+            "response_user_id": self.user2.user_id,
+        }
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_create_friend_request(self):
+        """
+        친구 요청 생성
+        """
+        self.client.force_authenticate(user=self.user1)
+        data = {
+            "request_user_id": self.user1.user_id,
+            "response_user_id": self.user2.user_id,
+        }
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_create_friend_request_to_me(self):
+        """
+        나에게 친구 요청 했을 때 400 에러 확인
+        """
+        self.client.force_authenticate(user=self.user1)
+        data = {
+            "request_user_id": self.user1.user_id,
+            "response_user_id": self.user1.user_id,
+        }
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_friend_request_already_requested(self):
+        """
+        이미 친구 요청을 보낸 친구에게 다시 요청을 보낸 경우 400 에러 확인
+        """
+        self.client.force_authenticate(user=self.user2)
+        data = {
+            "request_user_id": self.user2.user_id,
+            "response_user_id": self.user3.user_id,
+        }
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_friend_request_already_response(self):
+        """
+        이미 친구 요청을 받은 친구에게 요청을 보낸 경우 400 에러 확인
+        """
+        self.client.force_authenticate(user=self.user2)
+        data = {
+            "request_user_id": self.user3.user_id,
+            "response_user_id": self.user2.user_id,
+        }
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_friend_request_already_accepted(self):
+        """
+        이미 친구 요청을 수락한 경우 400 에러 확인
+        """
+        self.client.force_authenticate(user=self.user3)
+        data = {
+            "request_user_id": self.user3.user_id,
+            "response_user_id": self.user4.user_id,
+        }
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_friend_request_not_me(self):
+        """
+        내가 아닌 유저로 친구 요청을 보낸 경우 400 에러 확인
+        """
+        self.client.force_authenticate(user=self.user1)
+        data = {
+            "request_user_id": self.user2.user_id,
+            "response_user_id": self.user3.user_id,
+        }
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        data = {
+            "request_user_id": self.user3.user_id,
+            "response_user_id": self.user1.user_id,
+        }
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class FriendRequestDetailViewSetTestCase(APITestCase):
+    """
+    FriendRequestDetailViewSet 테스트
+    - method: PATCH, DELETE
+    """
+
+    def setUp(self):
+        # 사용자 생성
+        self.user1 = Users.objects.create_user(intra_id="user1")
+        self.user2 = Users.objects.create_user(intra_id="user2")
+        self.user3 = Users.objects.create_user(intra_id="user3")
+        self.user4 = Users.objects.create_user(intra_id="user4")
+
+        # 친구 요청 생성
+        self.friend_request1 = FriendRequests.objects.create(
+            request_user_id=self.user1,
+            response_user_id=self.user2,
+            status="0",
+        )
+        self.friend_request2 = FriendRequests.objects.create(
+            request_user_id=self.user3,
+            response_user_id=self.user4,
+            status="1",
+        )
+
+    def test_patch_friend_request_without_authenticate(self):
+        """
+        인증 없이 친구 요청 수락/거절 시, 403 에러 확인
+        """
+        url = reverse(
+            "friend_requests_detail",
+            kwargs={"request_id": self.friend_request1.request_id},
+        )
+        data = {"status": "1"}
+        response = self.client.patch(url, data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_patch_friend_request(self):
+        """
+        친구 요청 수락
+        """
+        self.client.force_authenticate(user=self.user2)
+        url = reverse(
+            "friend_requests_detail",
+            kwargs={"request_id": self.friend_request1.request_id},
+        )
+        data = {"status": "1"}
+        response = self.client.patch(url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_patch_friend_request_invalid_status(self):
+        """
+        잘못된 status로 요청 시, 400 에러 확인
+        """
+        self.client.force_authenticate(user=self.user2)
+        url = reverse(
+            "friend_requests_detail",
+            kwargs={"request_id": self.friend_request1.request_id},
+        )
+        data = {"status": "invalid"}
+        response = self.client.patch(url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_patch_friend_request_already_friend(self):
+        """
+        이미 친구인 경우, 400 에러 확인
+        """
+        self.client.force_authenticate(user=self.user3)
+        url = reverse(
+            "friend_requests_detail",
+            kwargs={"request_id": self.friend_request2.request_id},
+        )
+        data = {"status": "0"}
+        response = self.client.patch(url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_patch_friend_request_request_user(self):
+        """
+        보낸 유저가 다른 유저의 친구 요청을 수락/거절 시, 403 에러 확인
+        """
+        self.client.force_authenticate(user=self.user1)
+        url = reverse(
+            "friend_requests_detail",
+            kwargs={"request_id": self.friend_request1.request_id},
+        )
+        data = {"status": "1"}
+        response = self.client.patch(url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_patch_friend_request_another_user(self):
+        """
+        다른 유저가 친구 요청을 수락/거절 시, 403 에러 확인
+        """
+        self.client.force_authenticate(user=self.user3)
+        url = reverse(
+            "friend_requests_detail",
+            kwargs={"request_id": self.friend_request1.request_id},
+        )
+        data = {"status": "1"}
+        response = self.client.patch(url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_delete_friend_request_reject(self):
+        """
+        친구 요청 거절
+        """
+        self.client.force_authenticate(user=self.user2)
+        url = reverse(
+            "friend_requests_detail",
+            kwargs={"request_id": self.friend_request1.request_id},
+        )
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_delete_friend_request_delete(self):
+        """
+        친구 삭제
+        """
+        self.client.force_authenticate(user=self.user3)
+        url = reverse(
+            "friend_requests_detail",
+            kwargs={"request_id": self.friend_request2.request_id},
+        )
+        data = {"status": "invalid"}
+        response = self.client.delete(url, data)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_delete_friend_request_another_user(self):
+        """
+        다른 유저가 친구 삭제 시, 400 에러 확인
+        """
+        self.client.force_authenticate(user=self.user1)
+        url = reverse(
+            "friend_requests_detail",
+            kwargs={"request_id": self.friend_request2.request_id},
+        )
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/back/friendrequests/urls.py
+++ b/back/friendrequests/urls.py
@@ -5,6 +5,7 @@ urlpatterns = [
     path(
         "friend_requests/<uuid:user_id>/<str:status>/",
         views.FriendListViewSet.as_view({"get": "list"}),
+        name="friend_list",
     ),
     path(
         "friend_requests/<uuid:request_id>/",
@@ -14,6 +15,7 @@ urlpatterns = [
                 "delete": "destroy",
             }
         ),
+        name="friend_requests_detail",
     ),
     path(
         "friend_requests/",
@@ -22,5 +24,6 @@ urlpatterns = [
                 "post": "create",
             }
         ),
+        name="friend_requests",
     ),
 ]

--- a/back/friendrequests/views.py
+++ b/back/friendrequests/views.py
@@ -1,6 +1,6 @@
 from django.db.models import Q
 from rest_framework import viewsets
-from rest_framework.permissions import IsAuthenticated, BasePermission
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from .models import FriendRequests
@@ -24,9 +24,7 @@ class FriendListViewSet(viewsets.ModelViewSet):
 
         status = kwargs["status"]
         if status == "pending":
-            queryset = self.queryset.filter(
-                Q(response_user_id=user_id) & Q(status="pending")
-            )
+            queryset = self.queryset.filter(Q(response_user_id=user_id) & Q(status="0"))
         elif status == "accepted":
             queryset = self.queryset.filter(
                 Q(Q(request_user_id=user_id) | Q(response_user_id=user_id))
@@ -84,6 +82,10 @@ class FriendRequestDetailViewSet(viewsets.ModelViewSet):
         if owner != instance.response_user_id:
             raise ValidationError(
                 {"detail": "자신이 아닌 다른 사람의 친구 요청을 거절할 수 없습니다."}
+            )
+        if instance.status == "1":
+            raise ValidationError(
+                {"detail": "이미 수락한 친구 요청을 거절할 수 없습니다."}
             )
         return super().partial_update(request, *args, **kwargs)
 


### PR DESCRIPTION
### Summary

1. friend_requests test 추가했습니다.
2. friend_requests 동작을 일부 수정했습니다.


### Describe

#### 1. test 추가
- 각 ViewSet을 기준으로 테스트를 추가했습니다.

#### 2. friend_requests 일부 수정
- get 메소드에 pending 부분에서 필터부분을 "pending" -> "0" 으로 수정했습니다.
- friend_requests의 enum 중 "Reject" 를 제거했습니다.
- 이미 수락한 친구 요청의 status를 바꾸지 못하도록 설정했습니다.

### TODO
- 유저가 삭제될 때 잘 삭제되는지 등 다른 모델과 연동되어 움직이는 테스트도 추가하면 좋을 것 같습니다.
