### PR TITLE
[Back-26] modify UUID url to nickname accounts app

### DIFF
--- a/back/accounts/tests.py
+++ b/back/accounts/tests.py
@@ -26,6 +26,8 @@ class UsersViewSetTest(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+
+
     def test_add_user(self):
         """
         디버그용 post 잘 작동하는지 확인
@@ -47,6 +49,15 @@ class UsersDetailViewSetTest(APITestCase):
     def setUp(self):
         self.user = get_user_model().objects.create_user(intra_id="3")
         self.other_user = get_user_model().objects.create_user(intra_id="4")
+
+    def test_get_not_exists_user(self):
+        """
+        없는 유저일때 get test
+        """
+        self.client.force_authenticate(user=self.user)
+        url = reverse("users_detail", kwargs={"intra_id": 5})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_delete_without_authenticate(self):
         """

--- a/back/accounts/tests.py
+++ b/back/accounts/tests.py
@@ -52,7 +52,7 @@ class UsersDetailViewSetTest(APITestCase):
         """
         권한 없이 delete test
         """
-        url = reverse("users_detail", kwargs={"pk": self.other_user.pk})
+        url = reverse("users_detail", kwargs={"intra_id": self.user.intra_id})
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -62,7 +62,7 @@ class UsersDetailViewSetTest(APITestCase):
         """
         self.client.force_authenticate(user=self.user)
         initial_user_count = get_user_model().objects.count()
-        url = reverse("users_detail", kwargs={"pk": self.user.pk})
+        url = reverse("users_detail", kwargs={"intra_id": self.user.intra_id})
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         # 삭제 후 유저 수가 1 감소했는지 확인
@@ -76,7 +76,7 @@ class UsersDetailViewSetTest(APITestCase):
         """
         self.client.force_authenticate(user=self.user)
         initial_user_count = get_user_model().objects.count()
-        url = reverse("users_detail", kwargs={"pk": self.other_user.pk})
+        url = reverse("users_detail", kwargs={"intra_id": self.other_user.intra_id})
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         # 삭제 오류 후 유저 수가 동일한지 확인
@@ -88,7 +88,7 @@ class UsersDetailViewSetTest(APITestCase):
         """
         권한 없이 patch test
         """
-        url = reverse("users_detail", kwargs={"pk": self.other_user.pk})
+        url = reverse("users_detail", kwargs={"intra_id": self.user.intra_id})
         response = self.client.patch(url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -97,7 +97,7 @@ class UsersDetailViewSetTest(APITestCase):
         기본적인 patch test
         """
         self.client.force_authenticate(user=self.user)
-        url = reverse("users_detail", kwargs={"pk": self.user.pk})
+        url = reverse("users_detail", kwargs={"intra_id": self.user.intra_id})
         self.assertEqual(self.user.nickname, "3")
         data = {"nickname": "changed"}
         response = self.client.patch(url, data)
@@ -113,7 +113,7 @@ class UsersDetailViewSetTest(APITestCase):
         수정하면 안 되는 필드 테스트
         """
         self.client.force_authenticate(user=self.user)
-        url = reverse("users_detail", kwargs={"pk": self.user.pk})
+        url = reverse("users_detail", kwargs={"intra_id": self.user.intra_id})
         data = {"user_id": "1"}
         response = self.client.patch(url, data)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -123,7 +123,7 @@ class UsersDetailViewSetTest(APITestCase):
         동일한 닉네임으로 변경하는 경우 테스트
         """
         self.client.force_authenticate(user=self.user)
-        url = reverse("users_detail", kwargs={"pk": self.user.pk})
+        url = reverse("users_detail", kwargs={"intra_id": self.user.intra_id})
         data = {"nickname": self.other_user.nickname}
         response = self.client.patch(url, data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/back/accounts/urls.py
+++ b/back/accounts/urls.py
@@ -9,7 +9,7 @@ urlpatterns = [
         name="users",
     ),
     path(
-        "users/<uuid:pk>/",
+        "users/<str:intra_id>/",
         views.UsersDetailViewSet.as_view(
             {"get": "list", "patch": "partial_update", "delete": "destroy"}
         ),

--- a/back/accounts/views.py
+++ b/back/accounts/views.py
@@ -77,6 +77,8 @@ class UsersDetailViewSet(viewsets.ModelViewSet):
         GET method override
         """
         queryset = UsersViewSet.queryset.filter(intra_id=kwargs["intra_id"])
+        if not queryset.exists():
+            raise ValidationError({"detail": "존재하지 않는 사용자입니다."})
         serializer = UsersDetailSerializer(queryset, many=True)
         return Response(serializer.data)
 

--- a/back/accounts/views.py
+++ b/back/accounts/views.py
@@ -52,6 +52,7 @@ class UsersDetailViewSet(viewsets.ModelViewSet):
     queryset = Users.objects.all()
     serializer_class = UsersDetailSerializer
     http_method_names = ["get", "patch", "delete"]  # TODO delete 나중에 제거 예정
+    lookup_field = "intra_id"
 
     # 우선 nickname과 profile_image를 제외한 모든 필드를 수정 불가로 설정
     can_not_change_fields = (
@@ -75,7 +76,7 @@ class UsersDetailViewSet(viewsets.ModelViewSet):
         """
         GET method override
         """
-        queryset = Users.objects.filter(pk=kwargs["pk"])
+        queryset = UsersViewSet.queryset.filter(intra_id=kwargs["intra_id"])
         serializer = UsersDetailSerializer(queryset, many=True)
         return Response(serializer.data)
 
@@ -83,26 +84,33 @@ class UsersDetailViewSet(viewsets.ModelViewSet):
         """
         DELETE method override
         """
-        instance = self.get_object()
-        if request.user.pk != kwargs["pk"]:
+        user = Users.objects.get(intra_id=kwargs["intra_id"])
+        if request.user.intra_id != user.intra_id:
             raise PermissionDenied(
                 {"detail": "다른 사용자의 정보는 삭제할 수 없습니다."}
             )
-        if instance.profile_image:
+        if user.profile_image:
             try:
                 os.remove(
-                    os.path.join(settings.MEDIA_ROOT, instance.profile_image.name)
+                    os.path.join(settings.MEDIA_ROOT, user.profile_image.name)
                 )
             except FileNotFoundError:
                 print("File not found")
-        self.perform_destroy(instance)
+        self.perform_destroy(user)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     def partial_update(self, request, *args, **kwargs):
         """
         PATCH method override
         """
-        if request.user.pk != kwargs["pk"]:
+        try:
+            user = Users.objects.get(intra_id=kwargs["intra_id"])
+        except Users.DoesNotExist:
+            return Response(
+                {"error": "없는 유저입니다."}, status=status.HTTP_404_NOT_FOUND
+            )
+
+        if request.user.intra_id != user.intra_id:
             raise PermissionDenied(
                 {"detail": "다른 사용자의 정보는 수정할 수 없습니다."}
             )
@@ -111,9 +119,10 @@ class UsersDetailViewSet(viewsets.ModelViewSet):
                 raise PermissionDenied(
                     {"detail": f"{field}는 수정할 수 없는 필드입니다."}
                 )
-        instance = self.get_object()
+        instance = user
         previous_image = instance.profile_image
         response = super().partial_update(request, *args, **kwargs)
+
         if previous_image and request.data.get("profile_image") is not None:
             os.remove(os.path.join(settings.MEDIA_ROOT, previous_image.name))
         return response


### PR DESCRIPTION
### Summary
- accounts/url에서 uuid 인자를 intra_id로 수정했습니다.
- 바뀐 url에 맞게 test를 수정했습니다.
### Describe
#### accounts/url에서 uuid 인자를 intra_id로 수정했습니다.
- users의 상세 정보를 확인하기 위해서는 기존에는 users/user의 uuid로 조회했습니다.
- uuid다 보기 가독성의 문제도 있어서 url는 users/intra_id로 조회가 가능하도록 수정했습니다.
### TODO
- accounts의 users 모델 같은 경우 uuid를 intra_id로 옮기는 과정이 수월했습니다.
- 하지만 이것을 fk로 사용하는 다른 모델들을 어떻게 해야할지 고민입니다.
