### PR TITLE
[Back-27] change UUID to nickname games friendrequests

### DIFF
--- a/back/friendrequests/serializers.py
+++ b/back/friendrequests/serializers.py
@@ -6,13 +6,15 @@ from .models import FriendRequests
 
 class FriendListSerializer(serializers.ModelSerializer):
     friend_request = UsersSerializer(read_only=True)
+    request_intra_id = serializers.CharField(source="request_user_id.intra_id")
+    response_intra_id = serializers.CharField(source="response_user_id.intra_id")
 
     class Meta:
         model = FriendRequests
         fields = (
             "request_id",
-            "request_user_id",
-            "response_user_id",
+            "request_intra_id",
+            "response_intra_id",
             "status",
             "friend_request",
         )

--- a/back/friendrequests/tests.py
+++ b/back/friendrequests/tests.py
@@ -95,7 +95,7 @@ class FriendListViewSetTestCase(APITestCase):
             "friend_list", kwargs={"intra_id": self.user1.intra_id, "status": "all"}
         )
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
 class FriendRequestViewSetTestCase(APITestCase):

--- a/back/friendrequests/tests.py
+++ b/back/friendrequests/tests.py
@@ -34,7 +34,7 @@ class FriendListViewSetTestCase(APITestCase):
         인증 없이 친구 요청 리스트 확인 시, 403 에러 확인
         """
         url = reverse(
-            "friend_list", kwargs={"user_id": self.user1.user_id, "status": "all"}
+            "friend_list", kwargs={"intra_id": self.user1.intra_id, "status": "all"}
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -45,7 +45,7 @@ class FriendListViewSetTestCase(APITestCase):
         """
         self.client.force_authenticate(user=self.user1)
         url = reverse(
-            "friend_list", kwargs={"user_id": self.user1.user_id, "status": "all"}
+            "friend_list", kwargs={"intra_id": self.user1.intra_id, "status": "all"}
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -55,9 +55,9 @@ class FriendListViewSetTestCase(APITestCase):
         """
         pending 친구 요청 리스트 확인
         """
-        self.client.force_authenticate(user=self.user1)
+        self.client.force_authenticate(user=self.user2)
         url = reverse(
-            "friend_list", kwargs={"user_id": self.user2.user_id, "status": "pending"}
+            "friend_list", kwargs={"intra_id": self.user2.intra_id, "status": "pending"}
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -69,7 +69,7 @@ class FriendListViewSetTestCase(APITestCase):
         """
         self.client.force_authenticate(user=self.user1)
         url = reverse(
-            "friend_list", kwargs={"user_id": self.user1.user_id, "status": "accepted"}
+            "friend_list", kwargs={"intra_id": self.user1.intra_id, "status": "accepted"}
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -81,7 +81,18 @@ class FriendListViewSetTestCase(APITestCase):
         """
         self.client.force_authenticate(user=self.user1)
         url = reverse(
-            "friend_list", kwargs={"user_id": self.user1.user_id, "status": "invalid"}
+            "friend_list", kwargs={"intra_id": self.user1.intra_id, "status": "invalid"}
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_get_list_another_user(self):
+        """
+        다른 유저의 친구 요청 리스트 확인 시, 403 에러 확인
+        """
+        self.client.force_authenticate(user=self.user2)
+        url = reverse(
+            "friend_list", kwargs={"intra_id": self.user1.intra_id, "status": "all"}
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -120,8 +131,8 @@ class FriendRequestViewSetTestCase(APITestCase):
         인증 없이 친구 요청 생성 시, 403 에러 확인
         """
         data = {
-            "request_user_id": self.user1.user_id,
-            "response_user_id": self.user2.user_id,
+            "request_user_id": self.user1.intra_id,
+            "response_user_id": self.user2.intra_id,
         }
         response = self.client.post(self.url, data)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -132,8 +143,8 @@ class FriendRequestViewSetTestCase(APITestCase):
         """
         self.client.force_authenticate(user=self.user1)
         data = {
-            "request_user_id": self.user1.user_id,
-            "response_user_id": self.user2.user_id,
+            "request_user_id": self.user1.intra_id,
+            "response_user_id": self.user2.intra_id,
         }
         response = self.client.post(self.url, data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -144,8 +155,8 @@ class FriendRequestViewSetTestCase(APITestCase):
         """
         self.client.force_authenticate(user=self.user1)
         data = {
-            "request_user_id": self.user1.user_id,
-            "response_user_id": self.user1.user_id,
+            "request_user_id": self.user1.intra_id,
+            "response_user_id": self.user1.intra_id,
         }
         response = self.client.post(self.url, data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -156,8 +167,8 @@ class FriendRequestViewSetTestCase(APITestCase):
         """
         self.client.force_authenticate(user=self.user2)
         data = {
-            "request_user_id": self.user2.user_id,
-            "response_user_id": self.user3.user_id,
+            "request_user_id": self.user2.intra_id,
+            "response_user_id": self.user3.intra_id,
         }
         response = self.client.post(self.url, data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -168,8 +179,8 @@ class FriendRequestViewSetTestCase(APITestCase):
         """
         self.client.force_authenticate(user=self.user2)
         data = {
-            "request_user_id": self.user3.user_id,
-            "response_user_id": self.user2.user_id,
+            "request_user_id": self.user3.intra_id,
+            "response_user_id": self.user2.intra_id,
         }
         response = self.client.post(self.url, data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -180,8 +191,8 @@ class FriendRequestViewSetTestCase(APITestCase):
         """
         self.client.force_authenticate(user=self.user3)
         data = {
-            "request_user_id": self.user3.user_id,
-            "response_user_id": self.user4.user_id,
+            "request_user_id": self.user3.intra_id,
+            "response_user_id": self.user4.intra_id,
         }
         response = self.client.post(self.url, data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -192,15 +203,15 @@ class FriendRequestViewSetTestCase(APITestCase):
         """
         self.client.force_authenticate(user=self.user1)
         data = {
-            "request_user_id": self.user2.user_id,
-            "response_user_id": self.user3.user_id,
+            "request_user_id": self.user2.intra_id,
+            "response_user_id": self.user3.intra_id,
         }
         response = self.client.post(self.url, data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         data = {
-            "request_user_id": self.user3.user_id,
-            "response_user_id": self.user1.user_id,
+            "request_user_id": self.user3.intra_id,
+            "response_user_id": self.user1.intra_id,
         }
         response = self.client.post(self.url, data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/back/friendrequests/urls.py
+++ b/back/friendrequests/urls.py
@@ -3,9 +3,18 @@ from . import views
 
 urlpatterns = [
     path(
-        "friend_requests/<uuid:user_id>/<str:status>/",
+        "friend_requests/<str:intra_id>/<str:status>/",
         views.FriendListViewSet.as_view({"get": "list"}),
         name="friend_list",
+    ),
+    path(
+        "friend_requests/",
+        views.FriendRequestViewSet.as_view(
+            {
+                "post": "create",
+            }
+        ),
+        name="friend_requests",
     ),
     path(
         "friend_requests/<uuid:request_id>/",
@@ -17,13 +26,5 @@ urlpatterns = [
         ),
         name="friend_requests_detail",
     ),
-    path(
-        "friend_requests/",
-        views.FriendRequestViewSet.as_view(
-            {
-                "post": "create",
-            }
-        ),
-        name="friend_requests",
-    ),
+
 ]

--- a/back/friendrequests/views.py
+++ b/back/friendrequests/views.py
@@ -28,17 +28,17 @@ class FriendListViewSet(viewsets.ModelViewSet):
             raise ValidationError({"detail": "존재하지 않는 사용자입니다."})
         user_id = queryset.first().user_id
         if user_id != request.user.user_id:
-            raise ValidationError({"detail": "자신의 친구 목록만 볼 수 있습니다."})
+            return Response({"error": "자신의 친구 목록만 볼 수 있습니다."}, status=status.HTTP_403_FORBIDDEN)
 
-        status = kwargs["status"]
-        if status == "pending":
+        url_status = kwargs["status"]
+        if url_status == "pending":
             queryset = self.queryset.filter(Q(response_user_id=user_id) & Q(status="0"))
-        elif status == "accepted":
+        elif url_status == "accepted":
             queryset = self.queryset.filter(
                 Q(Q(request_user_id=user_id) | Q(response_user_id=user_id))
                 & Q(status="1")
             )
-        elif status == "all":
+        elif url_status == "all":
             queryset = self.queryset.filter(
                 Q(request_user_id=user_id) | Q(response_user_id=user_id)
             )

--- a/back/friendrequests/views.py
+++ b/back/friendrequests/views.py
@@ -28,7 +28,10 @@ class FriendListViewSet(viewsets.ModelViewSet):
             raise ValidationError({"detail": "존재하지 않는 사용자입니다."})
         user_id = queryset.first().user_id
         if user_id != request.user.user_id:
-            return Response({"error": "자신의 친구 목록만 볼 수 있습니다."}, status=status.HTTP_403_FORBIDDEN)
+            return Response(
+                {"error": "자신의 친구 목록만 볼 수 있습니다."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
 
         url_status = kwargs["status"]
         if url_status == "pending":
@@ -92,7 +95,9 @@ class FriendRequestViewSet(viewsets.ModelViewSet):
         serializer.is_valid(raise_exception=True)
         self.perform_create(serializer)
         headers = self.get_success_headers(serializer.data)
-        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+        return Response(
+            serializer.data, status=status.HTTP_201_CREATED, headers=headers
+        )
 
 
 class FriendRequestDetailViewSet(viewsets.ModelViewSet):
@@ -107,11 +112,11 @@ class FriendRequestDetailViewSet(viewsets.ModelViewSet):
         instance = self.get_object()
         if owner != instance.response_user_id:
             raise ValidationError(
-                {"detail": "자신이 아닌 다른 사람의 친구 요청을 거절할 수 없습니다."}
+                {"detail": "자신이 아닌 다른 사람의 친구 요청을 수락할 수 없습니다."}
             )
         if instance.status == "1":
             raise ValidationError(
-                {"detail": "이미 수락한 친구 요청을 거절할 수 없습니다."}
+                {"detail": "이미 수락한 친구 요청을 다시 수락할 수 없습니다."}
             )
         return super().partial_update(request, *args, **kwargs)
 

--- a/back/games/serializers.py
+++ b/back/games/serializers.py
@@ -39,6 +39,23 @@ class GeneralGameLogsSerializer(serializers.ModelSerializer):
         return data
 
 
+class GeneralGameLogsListSerializer(serializers.ModelSerializer):
+    user_request = UsersSerializer(many=True, read_only=True)
+    winner_intra_id = serializers.CharField(source="winner.intra_id")
+    loser_intra_id = serializers.CharField(source="loser.intra_id")
+
+    class Meta:
+        model = GeneralGameLogs
+        fields = (
+            "game_id",
+            "start_time",
+            "end_time",
+            "winner_intra_id",
+            "loser_intra_id",
+            "user_request",
+        )
+
+
 class JoinGeneralGameSerializer(serializers.ModelSerializer):
     user_request = UsersSerializer(read_only=True)
     game_request = GeneralGameLogsSerializer(read_only=True)
@@ -82,6 +99,25 @@ class TournamentGameLogsSerializer(serializers.ModelSerializer):
         if data["round"] <= 0:
             raise serializers.ValidationError("The round must be a positive number.")
         return data
+
+
+class TournamentGameLogsListSerializer(serializers.ModelSerializer):
+    user_request = UsersSerializer(many=True, read_only=True)
+    winner_intra_id = serializers.CharField(source="winner.intra_id")
+    loser_intra_id = serializers.CharField(source="loser.intra_id")
+
+    class Meta:
+        model = TournamentGameLogs
+        fields = (
+            "tournament_name",
+            "round",
+            "winner_intra_id",
+            "loser_intra_id",
+            "start_time",
+            "end_time",
+            "is_final",
+            "user_request",
+        )
 
 
 class JoinTournamentGameSerializer(serializers.ModelSerializer):

--- a/back/games/tests.py
+++ b/back/games/tests.py
@@ -42,8 +42,8 @@ class GeneralGameLogsViewSetTest(APITestCase):
         인증이 있을때 201 상태 코드 확인
         """
         self.client.force_authenticate(user=self.user1)
-        winner = self.user1.user_id
-        loser = self.user2.user_id
+        winner = self.user1.intra_id
+        loser = self.user2.intra_id
         data = {
             "start_time": self.start_time,
             "end_time": self.end_time,
@@ -57,8 +57,8 @@ class GeneralGameLogsViewSetTest(APITestCase):
         game_log = GeneralGameLogs.objects.get(game_id=response.data["game_id"])
         self.assertEqual(game_log.start_time, self.start_time)
         self.assertEqual(game_log.end_time, self.end_time)
-        self.assertEqual(game_log.winner.user_id, winner)
-        self.assertEqual(game_log.loser.user_id, loser)
+        self.assertEqual(game_log.winner.intra_id, winner)
+        self.assertEqual(game_log.loser.intra_id, loser)
 
         # JoinGeneralGame 모델에 게임 로그가 생성 하는지 확인
         self.assertTrue(JoinGeneralGame.objects.filter(user_id=self.user1).exists())
@@ -75,8 +75,8 @@ class GeneralGameLogsViewSetTest(APITestCase):
         winner랑 loser가 동일할때 테스트
         """
         self.client.force_authenticate(user=self.user1)
-        winner = self.user1.user_id
-        loser = self.user1.user_id
+        winner = self.user1.intra_id
+        loser = self.user1.intra_id
         data = {
             "start_time": self.start_time,
             "end_time": self.end_time,
@@ -91,8 +91,8 @@ class GeneralGameLogsViewSetTest(APITestCase):
         시작 시간이 끝나는 시간보다 이전인지 확인하는 테스트
         """
         self.client.force_authenticate(user=self.user1)
-        winner = self.user1.user_id
-        loser = self.user2.user_id
+        winner = self.user1.intra_id
+        loser = self.user2.intra_id
         data = {
             "start_time": self.end_time,
             "end_time": self.start_time,
@@ -107,8 +107,8 @@ class GeneralGameLogsViewSetTest(APITestCase):
         끝나는 시간이 미래보다 전인지 확인하는 테스트
         """
         self.client.force_authenticate(user=self.user1)
-        winner = self.user1.user_id
-        loser = self.user2.user_id
+        winner = self.user1.intra_id
+        loser = self.user2.intra_id
 
         data = {
             "start_time": self.end_time,
@@ -121,11 +121,11 @@ class GeneralGameLogsViewSetTest(APITestCase):
 
     def test_get_general_game_log_uuid_fk(self):
         """
-        get으로 create한 general_game_log/<uuid:fk>/ 잘 가져오는지 확인하는 테스트
+        get으로 create한 general_game_log/<str:intra_id>/ 잘 가져오는지 확인하는 테스트
         """
         self.client.force_authenticate(user=self.user1)
-        winner = self.user1.user_id
-        loser = self.user2.user_id
+        winner = self.user1.intra_id
+        loser = self.user2.intra_id
         data = {
             "start_time": self.start_time,
             "end_time": self.end_time,
@@ -137,14 +137,16 @@ class GeneralGameLogsViewSetTest(APITestCase):
 
         # get 으로 요청
         response = self.client.get(
-            reverse("general_game_logs_detail", kwargs={"fk": self.user1.user_id})
+            reverse(
+                "general_game_logs_detail", kwargs={"intra_id": self.user1.intra_id}
+            )
         )
 
         # get 데이터 확인
         self.assertEqual(response.data[0]["start_time"], self.start_time.isoformat())
         self.assertEqual(response.data[0]["end_time"], self.end_time.isoformat())
-        self.assertEqual(response.data[0]["winner"], winner)
-        self.assertEqual(response.data[0]["loser"], loser)
+        self.assertEqual(response.data[0]["winner_intra_id"], winner)
+        self.assertEqual(response.data[0]["loser_intra_id"], loser)
 
 
 class TournamentGameLogsViewSetTest(APITestCase):
@@ -167,8 +169,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
         data = {
             "tournament_name": self.tournament_name,
             "round": 1,
-            "winner": self.user1.user_id,
-            "loser": self.user2.user_id,
+            "winner": self.user1.intra_id,
+            "loser": self.user2.intra_id,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "is_final": False,
@@ -185,8 +187,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
         data = {
             "tournament_name": self.tournament_name,
             "round": 1,
-            "winner": self.user1.user_id,
-            "loser": self.user2.user_id,
+            "winner": self.user1.intra_id,
+            "loser": self.user2.intra_id,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "is_final": False,
@@ -201,8 +203,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
         )
         self.assertEqual(game_log.tournament_name, self.tournament_name)
         self.assertEqual(game_log.round, 1)
-        self.assertEqual(game_log.winner.user_id, self.user1.user_id)
-        self.assertEqual(game_log.loser.user_id, self.user2.user_id)
+        self.assertEqual(game_log.winner.intra_id, self.user1.intra_id)
+        self.assertEqual(game_log.loser.intra_id, self.user2.intra_id)
         self.assertEqual(game_log.start_time, self.start_time)
         self.assertEqual(game_log.end_time, self.end_time)
         self.assertEqual(game_log.is_final, False)
@@ -228,8 +230,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
         data = {
             "tournament_name": self.tournament_name,
             "round": 1,
-            "winner": self.user1.user_id,
-            "loser": self.user1.user_id,
+            "winner": self.user1.intra_id,
+            "loser": self.user1.intra_id,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "is_final": False,
@@ -246,8 +248,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
         data = {
             "tournament_name": self.tournament_name,
             "round": 1,
-            "winner": self.user1.user_id,
-            "loser": self.user2.user_id,
+            "winner": self.user1.intra_id,
+            "loser": self.user2.intra_id,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "is_final": False,
@@ -258,8 +260,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
         data2 = {
             "tournament_name": self.tournament_name,
             "round": 2,
-            "winner": self.user3.user_id,
-            "loser": self.user4.user_id,
+            "winner": self.user3.intra_id,
+            "loser": self.user4.intra_id,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "is_final": False,
@@ -270,8 +272,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
         data3 = {
             "tournament_name": self.tournament_name,
             "round": 3,
-            "winner": self.user3.user_id,
-            "loser": self.user1.user_id,
+            "winner": self.user3.intra_id,
+            "loser": self.user1.intra_id,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "is_final": True,
@@ -287,8 +289,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
         data = {
             "tournament_name": self.tournament_name,
             "round": 1,
-            "winner": self.user1.user_id,
-            "loser": self.user2.user_id,
+            "winner": self.user1.intra_id,
+            "loser": self.user2.intra_id,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "is_final": False,
@@ -299,8 +301,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
         data2 = {
             "tournament_name": self.tournament_name,
             "round": 1,
-            "winner": self.user3.user_id,
-            "loser": self.user4.user_id,
+            "winner": self.user3.intra_id,
+            "loser": self.user4.intra_id,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "is_final": False,
@@ -317,8 +319,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
         data = {
             "tournament_name": self.tournament_name,
             "round": 1,
-            "winner": self.user1.user_id,
-            "loser": self.user2.user_id,
+            "winner": self.user1.intra_id,
+            "loser": self.user2.intra_id,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "is_final": False,
@@ -329,8 +331,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
         data2 = {
             "tournament_name": self.tournament_name,
             "round": 2,
-            "winner": self.user3.user_id,
-            "loser": self.user4.user_id,
+            "winner": self.user3.intra_id,
+            "loser": self.user4.intra_id,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "is_final": False,
@@ -341,8 +343,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
         data3 = {
             "tournament_name": self.tournament_name,
             "round": 3,
-            "winner": self.user3.user_id,
-            "loser": self.user1.user_id,
+            "winner": self.user3.intra_id,
+            "loser": self.user1.intra_id,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "is_final": True,
@@ -354,12 +356,14 @@ class TournamentGameLogsViewSetTest(APITestCase):
             reverse("tournament_name_logs", kwargs={"name": self.tournament_name})
         )
         assert len(response.data) == 3
-        self.assertEqual(self.user1.user_id, response.data[0]["winner"])
-        self.assertEqual(self.user3.user_id, response.data[1]["winner"])
-        self.assertEqual(self.user3.user_id, response.data[2]["winner"])
+        self.assertEqual(self.user1.intra_id, response.data[0]["winner_intra_id"])
+        self.assertEqual(self.user3.intra_id, response.data[1]["winner_intra_id"])
+        self.assertEqual(self.user3.intra_id, response.data[2]["winner_intra_id"])
 
         response = self.client.get(
-            reverse("tournament_game_user_logs", kwargs={"fk": self.user1.user_id})
+            reverse(
+                "tournament_game_user_logs", kwargs={"intra_id": self.user1.intra_id}
+            )
         )
         assert len(response.data) == 2
         self.assertEqual(1, response.data[0]["round"])

--- a/back/games/urls.py
+++ b/back/games/urls.py
@@ -9,23 +9,23 @@ urlpatterns = [
         name="general_game_logs",
     ),
     path(
-        "general_game_logs/<uuid:fk>/",
-        views.GeneralGameLogsViewSet.as_view({"get": "list"}),
+        "general_game_logs/<str:intra_id>/",
+        views.GeneralGameLogsListViewSet.as_view({"get": "list"}),
         name="general_game_logs_detail",
     ),
     path(
         "tournament_game_logs/",
-        views.TournamentGameLogsViewSet.as_view({"post": "create"}),
+        views.TournamentGameLogsViewSet.as_view({"get": "list", "post": "create"}),
         name="create_tournament_game_logs",
     ),
     path(
-        "tournament_game_logs/<uuid:fk>/",
-        views.TournamentGameLogsViewSet.as_view({"get": "list"}),
+        "tournament_game_logs/users/<str:intra_id>/",
+        views.TournamentGameLogsListViewSet.as_view({"get": "list"}),
         name="tournament_game_user_logs",
     ),
     path(
-        "tournament_game_logs/<str:name>/",
-        views.TournamentGameLogsViewSet.as_view({"get": "list"}),
+        "tournament_game_logs/tournament/<str:name>/",
+        views.TournamentGameLogsListViewSet.as_view({"get": "list"}),
         name="tournament_name_logs",
     ),
 ]

--- a/back/games/views.py
+++ b/back/games/views.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import IntegrityError, DatabaseError
 from django.db.models import Q
@@ -8,7 +10,9 @@ from rest_framework.exceptions import ValidationError
 from accounts.models import Users
 from .serializers import (
     GeneralGameLogsSerializer,
+    GeneralGameLogsListSerializer,
     TournamentGameLogsSerializer,
+    TournamentGameLogsListSerializer,
     JoinGeneralGameSerializer,
     JoinTournamentGameSerializer,
 )
@@ -20,17 +24,69 @@ from .models import (
 )
 
 
+def is_exist_user(key, value):
+    try:
+        user = None
+        if key == "intra_id":
+            user = Users.objects.get(intra_id=value)
+        elif key == "user_id":
+            uuid.UUID(value)  # UUID 형식인지 확인, 안하면 get 내부 함수에서 raise 발생
+            user = Users.objects.get(user_id=value)
+        return user
+    except (ObjectDoesNotExist, ValueError):
+        return None
+
+
+def get_user_from_intra_id_or_user_id(ids):
+    """
+    intra_id 또는 user_id로 유저를 찾아 반환
+    """
+    user = is_exist_user("intra_id", ids)
+    if user is None:
+        user = is_exist_user("user_id", ids)
+        if user is None:
+            raise ValidationError({"error": "유저가 존재하지 않습니다."})
+    return user
+
+
+def create_with_intra_id_convert_to_user_id(self, request):
+    """
+    intra_id를 user_id로 변환하여 Game Log를 생성
+    """
+    winner_intra_id = request.data.get("winner")
+    loser_intra_id = request.data.get("loser")
+
+    winner_user = get_user_from_intra_id_or_user_id(winner_intra_id)
+    loser_user = get_user_from_intra_id_or_user_id(loser_intra_id)
+
+    request_copy_data = request.data.copy()
+    request_copy_data["winner"] = winner_user.user_id
+    request_copy_data["loser"] = loser_user.user_id
+
+    serializer = self.get_serializer(data=request_copy_data)
+    serializer.is_valid(raise_exception=True)
+    self.perform_create(serializer)
+    headers = self.get_success_headers(serializer.data)
+    return (
+        winner_user,
+        loser_user,
+        Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers),
+    )
+
+
 class GeneralGameLogsViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
     queryset = GeneralGameLogs.objects.all()
     serializer_class = GeneralGameLogsSerializer
-    http_method_names = ["get", "post"]  # TODO debug를 위해 post 임시 추가
+    http_method_names = ["get", "post"]  # TODO debug를 위해 get 임시 추가
 
     # general game logs 생성 시 join general game 생성하는 오버라이딩 에러 발생
     # fk는 uuid가 아닌 인스턴스를 요구해서 생긴 에러인듯
     def create(self, request, *args, **kwargs):
         try:
-            response = super().create(request, *args, **kwargs)
+            winner_user, loser_user, response = create_with_intra_id_convert_to_user_id(
+                self, request
+            )
             game_id = response.data["game_id"]
             if not game_id:
                 return Response(
@@ -38,23 +94,8 @@ class GeneralGameLogsViewSet(viewsets.ModelViewSet):
                     status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 )
             game_instance = GeneralGameLogs.objects.get(game_id=game_id)
-            winner_uuid = request.data.get("winner")
-            loser_uuid = request.data.get("loser")
-            if winner_uuid and loser_uuid:
-                try:
-                    winner_user = Users.objects.get(user_id=winner_uuid)
-                    loser_user = Users.objects.get(user_id=loser_uuid)
-                except ObjectDoesNotExist:
-                    return Response(
-                        {"error": "유저가 존재하지 않습니다."},
-                        status=status.HTTP_404_NOT_FOUND,
-                    )
-                JoinGeneralGame.objects.create(
-                    game_id=game_instance, user_id=winner_user
-                )
-                JoinGeneralGame.objects.create(
-                    game_id=game_instance, user_id=loser_user
-                )
+            JoinGeneralGame.objects.create(game_id=game_instance, user_id=winner_user)
+            JoinGeneralGame.objects.create(game_id=game_instance, user_id=loser_user)
             return response
 
         except IntegrityError as e:
@@ -64,14 +105,24 @@ class GeneralGameLogsViewSet(viewsets.ModelViewSet):
                 {"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
 
+
+class GeneralGameLogsListViewSet(viewsets.ModelViewSet):
+    permission_classes = [IsAuthenticated]
+    queryset = GeneralGameLogs.objects.all()
+    serializer_class = GeneralGameLogsListSerializer
+
     def list(self, request, *args, **kwargs):
         # 밑에 if문은 debug를 위한 임시 get
-        if "fk" not in kwargs:
+        if "intra_id" not in kwargs:
             return super().list(request, *args, **kwargs)
 
-        user_id = kwargs["fk"]
-        # Q 객체는 복잡한 쿼리 조건을 사용할 때 사용, 밑에는 or 조건
-        queryset = self.queryset.filter(Q(winner=user_id) | Q(loser=user_id))
+        user = get_user_from_intra_id_or_user_id(kwargs["intra_id"])
+        if user is None:
+            return Response(
+                {"error": "유저가 존재하지 않습니다."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        queryset = self.queryset.filter(Q(winner=user.user_id) | Q(loser=user.user_id))
         serializer = self.serializer_class(queryset, many=True)
         return Response(serializer.data)
 
@@ -93,11 +144,13 @@ class TournamentGameLogsViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
     queryset = TournamentGameLogs.objects.all()
     serializer_class = TournamentGameLogsSerializer
-    http_method_names = ["get", "post"]  # TODO debug를 위해 post 임시 추가
+    http_method_names = ["get", "post"]  # TODO debug를 위해 get 임시 추가
 
     def create(self, request, *args, **kwargs):
         try:
-            response = super().create(request, *args, **kwargs)
+            winner_user, loser_user, response = create_with_intra_id_convert_to_user_id(
+                self, request
+            )
             tournament_name = response.data["tournament_name"]
             if not tournament_name:
                 return Response(
@@ -108,24 +161,10 @@ class TournamentGameLogsViewSet(viewsets.ModelViewSet):
                 tournament_name=tournament_name,
                 round=response.data["round"],
             )
-            tournament_name = request.data.get("tournament_name")
-            winner_uuid = request.data.get("winner")
-            loser_uuid = request.data.get("loser")
-            if winner_uuid and loser_uuid and tournament_name:
-                try:
-                    winner_user = Users.objects.get(user_id=winner_uuid)
-                    loser_user = Users.objects.get(user_id=loser_uuid)
-                except ObjectDoesNotExist:
-                    return Response(
-                        {"error": "유저가 존재하지 않습니다."},
-                        status=status.HTTP_404_NOT_FOUND,
-                    )
-                JoinTournamentGame.objects.create(
-                    game_id=game_instance, user_id=winner_user
-                )
-                JoinTournamentGame.objects.create(
-                    game_id=game_instance, user_id=loser_user
-                )
+            JoinTournamentGame.objects.create(
+                game_id=game_instance, user_id=winner_user
+            )
+            JoinTournamentGame.objects.create(game_id=game_instance, user_id=loser_user)
             return response
 
         except IntegrityError as e:
@@ -135,18 +174,29 @@ class TournamentGameLogsViewSet(viewsets.ModelViewSet):
                 {"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
 
+
+class TournamentGameLogsListViewSet(viewsets.ModelViewSet):
+    permission_classes = [IsAuthenticated]
+    queryset = TournamentGameLogs.objects.all()
+    serializer_class = TournamentGameLogsListSerializer
+
     def list(self, request, *args, **kwargs):
         # 밑에 if문은 debug를 위한 임시 get
-        print(kwargs)
-        if "fk" not in kwargs and "name" not in kwargs:
+        if "intra_id" not in kwargs and "name" not in kwargs:
             return super().list(request, *args, **kwargs)
 
-        if "fk" in kwargs and "name" not in kwargs:
-            user_id = kwargs["fk"]
-            queryset = self.queryset.filter(Q(winner=user_id) | Q(loser=user_id))
-        elif "name" in kwargs and "fk" not in kwargs:
-            name = kwargs["name"]
-            queryset = self.queryset.filter(tournament_name=name)
+        if "intra_id" in kwargs and "name" not in kwargs:
+            user = get_user_from_intra_id_or_user_id(kwargs["intra_id"])
+            if user is None:
+                return Response(
+                    {"error": "유저가 존재하지 않습니다."},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+            queryset = self.queryset.filter(
+                Q(winner=user.user_id) | Q(loser=user.user_id)
+            )
+        elif "name" in kwargs and "intra_id" not in kwargs:
+            queryset = self.queryset.filter(tournament_name=kwargs["name"])
         else:
             raise ValidationError({"detail": "잘못된 요청입니다."})
         serializer = self.serializer_class(queryset, many=True)


### PR DESCRIPTION
### Summary

#### FriendRequests와 Games
- intra_id에 맞춰 url 수정
- serializer 필드를 uuid -> intra_id로 수정
- 수정된 url에 맞춰서 viewset 수정
- 수정 사항에 맞춰서 test 수정

---

### Describe

#### 1. FriendRequests

##### 1.1 `friend_requests/<str:intra_id>/<str:status>/`
  - method: `GET`
  - status: all(전체), pending(받은 요청), accepted(친구만)
##### 1.2 `friend_requests/`
  - method: `POST`
  - body는 변한 것이 없으나 **uuid** 대신 **intra_id** 를 받고 **내부에서 변환하도록 변경** 했습니다.
##### 1.3 `friend_requests/<uuid:request_id>/`
  - method: `PATCH` , `DELETE`
  - intra_id를 받는 방향으로 찾아보았으나 **친구 관계 자체를 특정할 pk를 요구** 하기에 intra_id를 받을 수 없습니다.
  - 이에 request_id, 즉 pk를 사용하는 방향으로 구현했습니다.

#### 2. Games

##### 2.0 공통 함수들
- `is_exist_user`
  - 주어진 key와 value로 존재하는 usre인지 탐색하는 함수
  - key는 intra_id와 user_id만 받습니다.
- `get_user_from_intra_id_or_user_id`
  - 주어진 id를 intra_id 필드와 uuid 필드로 탐색하는 함수
  - intra_id로 먼저 탐색하고 없을 때 uuid로 탐색합니다. (DRF 지원 사이트에서도 테스트가 가능하도록 만든 기능입니다.)
  - 만약 조건에 맞는 유저가 없다면 None을 반환합니다.
- `create_with_intra_id_convert_to_user_id`
  - POST 동작 중 request의 body에 있는 intra_id를 user_id로 변환하여 생성하는 함수입니다.
  - winner_user, loser_user, 생성 Response를 반환합니다.

##### 2.1 `general_game_logs/`
  - method: `GET` (for debug), `POST`
  - GET은 전체 로그를 보여주는 디버그용 메소드입니다.
  - **유저가 존재하는지 확인하는 로직이 공통 함수에 존재** 하기에 확인 과정을 삭제했습니다.

##### 2.2 `general_game_logs/<str:intra_id>/`
  - method: `GET`
  - uuid대신 intra_id를 필드로 갖는 새로운 serializer를 생성하여 사용했습니다.

##### 2.3 `tournament_game_logs/`
  - method: `GET` (for debug), `POST`
  - GET은 전체 로그를 보여주는 디버그용 메소드입니다.
  - **유저가 존재하는지 확인하는 로직이 공통 함수에 존재** 하기에 확인 과정을 삭제했습니다.
 
##### 2.4 `tournament_game_logs/users/<str:intra_id>/`
  - method: `GET`
  - uuid가 str이 되어 타입으로 구분이 불가능해졌습니다.
  - 그래서 **중간 url을 추가** 하여 사용자와 토너먼트를 구분했습니다.

##### 2.5 `tournament_game_logs/tournament/<str:name>/`
  - method: `GET`
  - uuid가 str이 되어 타입으로 구분이 불가능해졌습니다.
  - 그래서 **중간 url을 추가** 하여 사용자와 토너먼트를 구분했습니다.

---

### TODO
- friend_requests 중 **body를 받는 부분을 intra_id를 받아 내부에서 변경하도록 설정** 했습니다. 하지만 **장고는 필드의 타입인 uuid 타입을 인지하고 받기때문에 djang rest framework에서 자동으로 만들어주는 페이지에선 uuid를 넘겨주게 되어있습니다.** 이에 현재 로직에선 없는 유저라는 에러를 던져줍니다. games 처럼 uuid가 들어왔을 때도 처리해주는 것을 만들어주면 되지만 debug 용이라 꼭 필요한지 의문이 들기에 추가하지 않았습니다만 불편할 경우 추가할 계획입니다.
- debug용 GET을 제거해야 합니다.
