### PR TITLE
[Back-28] modified game logs

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -6,3 +6,5 @@
 # Datasource local storage ignored files
 /dataSources/
 /dataSources.local.xml
+# GitHub Copilot persisted chat sessions
+/copilot/chatSessions

--- a/.idea/backend.iml
+++ b/.idea/backend.iml
@@ -16,7 +16,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 3.12 (backend)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">

--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectTasksOptions">
-    <TaskOptions isEnabled="false">
+    <TaskOptions isEnabled="true">
       <option name="arguments" value="$FilePath$" />
       <option name="checkSyntaxErrors" value="true" />
       <option name="description" />

--- a/back/games/models.py
+++ b/back/games/models.py
@@ -6,17 +6,17 @@ class GeneralGameLogs(models.Model):
     game_id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     start_time = models.DateTimeField()
     end_time = models.DateTimeField()
-    winner = models.ForeignKey(
+    player1 = models.ForeignKey(
         "accounts.Users",
         on_delete=models.CASCADE,
-        db_column="winner",
-        related_name="general_winner",
+        db_column="player1",
+        related_name="general_player1",
     )
-    loser = models.ForeignKey(
+    player2 = models.ForeignKey(
         "accounts.Users",
         on_delete=models.CASCADE,
-        db_column="loser",
-        related_name="general_loser",
+        db_column="player2",
+        related_name="general_player2",
     )
 
     class Meta:
@@ -27,17 +27,17 @@ class GeneralGameLogs(models.Model):
 class TournamentGameLogs(models.Model):
     tournament_name = models.CharField(max_length=20)
     round = models.IntegerField()
-    winner = models.ForeignKey(
+    player1 = models.ForeignKey(
         "accounts.Users",
         on_delete=models.CASCADE,
-        db_column="winner",
-        related_name="tournament_winner",
+        db_column="player1",
+        related_name="tournament_player1",
     )
-    loser = models.ForeignKey(
+    player2 = models.ForeignKey(
         "accounts.Users",
         on_delete=models.CASCADE,
-        db_column="loser",
-        related_name="tournament_loser",
+        db_column="player2",
+        related_name="tournament_player2",
     )
     start_time = models.DateTimeField()
     end_time = models.DateTimeField()

--- a/back/games/models.py
+++ b/back/games/models.py
@@ -18,6 +18,8 @@ class GeneralGameLogs(models.Model):
         db_column="player2",
         related_name="general_player2",
     )
+    player1_score = models.IntegerField()
+    player2_score = models.IntegerField()
 
     class Meta:
         db_table = "GeneralGameLogs"
@@ -39,6 +41,8 @@ class TournamentGameLogs(models.Model):
         db_column="player2",
         related_name="tournament_player2",
     )
+    player1_score = models.IntegerField()
+    player2_score = models.IntegerField()
     start_time = models.DateTimeField()
     end_time = models.DateTimeField()
     is_final = models.BooleanField()

--- a/back/games/models.py
+++ b/back/games/models.py
@@ -23,7 +23,7 @@ class GeneralGameLogs(models.Model):
 
     class Meta:
         db_table = "GeneralGameLogs"
-        ordering = ["start_time"]
+        ordering = ["-start_time"]
 
 
 class TournamentGameLogs(models.Model):
@@ -49,7 +49,7 @@ class TournamentGameLogs(models.Model):
 
     class Meta:
         db_table = "TournamentGameLogs"
-        ordering = ["start_time"]
+        ordering = ["-start_time"]
         constraints = [
             models.UniqueConstraint(
                 fields=["tournament_name", "round"], name="tournament_game_id"

--- a/back/games/models.py
+++ b/back/games/models.py
@@ -2,27 +2,6 @@ import uuid
 from django.db import models
 
 
-class JoinGeneralGame(models.Model):
-    game_id = models.ForeignKey(
-        "GeneralGameLogs",
-        on_delete=models.CASCADE,
-        db_column="game_id",
-    )
-    user_id = models.ForeignKey(
-        "accounts.Users",
-        on_delete=models.CASCADE,
-        db_column="user_id",
-    )
-
-    class Meta:
-        db_table = "JoinGeneralGame"
-        constraints = [
-            models.UniqueConstraint(
-                fields=["game_id", "user_id"], name="join_general_game_id"
-            )
-        ]
-
-
 class GeneralGameLogs(models.Model):
     game_id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     start_time = models.DateTimeField()
@@ -43,27 +22,6 @@ class GeneralGameLogs(models.Model):
     class Meta:
         db_table = "GeneralGameLogs"
         ordering = ["start_time"]
-
-
-class JoinTournamentGame(models.Model):
-    game_id = models.ForeignKey(
-        "TournamentGameLogs",
-        on_delete=models.CASCADE,
-        db_column="game_id",
-    )
-    user_id = models.ForeignKey(
-        "accounts.Users",
-        on_delete=models.CASCADE,
-        db_column="user_id",
-    )
-
-    class Meta:
-        db_table = "JoinTournamentGame"
-        constraints = [
-            models.UniqueConstraint(
-                fields=["game_id", "user_id"], name="join_tournament_game_id"
-            )
-        ]
 
 
 class TournamentGameLogs(models.Model):

--- a/back/games/serializers.py
+++ b/back/games/serializers.py
@@ -35,6 +35,8 @@ class GeneralGameLogsSerializer(serializers.ModelSerializer):
             "end_time",
             "player1_intra_id",
             "player2_intra_id",
+            "player1_score",
+            "player2_score",
         )
 
     def create(self, validated_data):
@@ -53,6 +55,8 @@ class GeneralGameLogsSerializer(serializers.ModelSerializer):
         # 끝나는 시간이 현재 시각보다 이후인지 확인
         if data["end_time"] > timezone.now():
             raise serializers.ValidationError("End time must not be in the future.")
+        if data["player1_score"] < 0 or data["player2_score"] < 0:
+            raise serializers.ValidationError("Score must be a non-negative number.")
         return data
 
 
@@ -68,6 +72,8 @@ class GeneralGameLogsListSerializer(serializers.ModelSerializer):
             "end_time",
             "player1_user",
             "player2_user",
+            "player1_score",
+            "player2_score",
         )
 
     def create(self, validated_data):
@@ -85,6 +91,8 @@ class TournamentGameLogsSerializer(serializers.ModelSerializer):
             "round",
             "player1_intra_id",
             "player2_intra_id",
+            "player1_score",
+            "player2_score",
             "start_time",
             "end_time",
             "is_final",
@@ -105,6 +113,8 @@ class TournamentGameLogsSerializer(serializers.ModelSerializer):
         # 라운드가 양수인지 확인
         if data["round"] <= 0:
             raise serializers.ValidationError("The round must be a positive number.")
+        if data["player1_score"] < 0 or data["player2_score"] < 0:
+            raise serializers.ValidationError("Score must be a non-negative number.")
         return data
 
 
@@ -119,6 +129,8 @@ class TournamentGameLogsListSerializer(serializers.ModelSerializer):
             "round",
             "player1_user",
             "player2_user",
+            "player1_score",
+            "player2_score",
             "start_time",
             "end_time",
             "is_final",

--- a/back/games/serializers.py
+++ b/back/games/serializers.py
@@ -3,8 +3,6 @@ from rest_framework import serializers
 from .models import (
     GeneralGameLogs,
     TournamentGameLogs,
-    JoinGeneralGame,
-    JoinTournamentGame,
 )
 from accounts.serializers import UsersSerializer
 
@@ -56,20 +54,6 @@ class GeneralGameLogsListSerializer(serializers.ModelSerializer):
         )
 
 
-class JoinGeneralGameSerializer(serializers.ModelSerializer):
-    user_request = UsersSerializer(read_only=True)
-    game_request = GeneralGameLogsSerializer(read_only=True)
-
-    class Meta:
-        model = JoinGeneralGame
-        fields = (
-            "game_id",
-            "user_id",
-            "user_request",
-            "game_request",
-        )
-
-
 class TournamentGameLogsSerializer(serializers.ModelSerializer):
     user_request = UsersSerializer(many=True, read_only=True)
 
@@ -117,18 +101,4 @@ class TournamentGameLogsListSerializer(serializers.ModelSerializer):
             "end_time",
             "is_final",
             "user_request",
-        )
-
-
-class JoinTournamentGameSerializer(serializers.ModelSerializer):
-    user_request = UsersSerializer(read_only=True)
-    game_request = TournamentGameLogsSerializer(read_only=True)
-
-    class Meta:
-        model = JoinTournamentGame
-        fields = (
-            "game_id",
-            "user_id",
-            "user_request",
-            "game_request",
         )

--- a/back/games/serializers.py
+++ b/back/games/serializers.py
@@ -5,10 +5,27 @@ from .models import (
     TournamentGameLogs,
 )
 from accounts.serializers import UsersSerializer
+from accounts.models import Users
+
+
+def create_game_log(validated_data, is_general=True):
+    validated_data["player1"] = Users.objects.get(
+        intra_id=validated_data["player1"]["intra_id"]
+    )
+    validated_data["player2"] = Users.objects.get(
+        intra_id=validated_data["player2"]["intra_id"]
+    )
+    game_log = (
+        GeneralGameLogs.objects.create(**validated_data)
+        if is_general
+        else TournamentGameLogs.objects.create(**validated_data)
+    )
+    return game_log
 
 
 class GeneralGameLogsSerializer(serializers.ModelSerializer):
-    user_request = UsersSerializer(many=True, read_only=True)
+    player1_intra_id = serializers.CharField(source="player1.intra_id")
+    player2_intra_id = serializers.CharField(source="player2.intra_id")
 
     class Meta:
         model = GeneralGameLogs
@@ -16,17 +33,19 @@ class GeneralGameLogsSerializer(serializers.ModelSerializer):
             "game_id",
             "start_time",
             "end_time",
-            "winner",
-            "loser",
-            "user_request",
+            "player1_intra_id",
+            "player2_intra_id",
         )
+
+    def create(self, validated_data):
+        return create_game_log(validated_data)
 
     # winner랑 loser가 동일하면 에러 발생
     # 데이터 유효성 검사는 1. model 수준에서 2. serializer에서 가능한데
     # 1. clean을 오버라이딩해서 Django의 폼 시스템이나 관리자 사이트에서 주로 유용
     # 2. api에서 유용
     def validate(self, data):
-        if data["winner"] == data["loser"]:
+        if data["player1"] == data["player2"]:
             raise serializers.ValidationError("Winner and loser must be different.")
         # 시작 시간이 끝나는 시간보다 이전인지 확인
         if data["start_time"] >= data["end_time"]:
@@ -38,9 +57,8 @@ class GeneralGameLogsSerializer(serializers.ModelSerializer):
 
 
 class GeneralGameLogsListSerializer(serializers.ModelSerializer):
-    user_request = UsersSerializer(many=True, read_only=True)
-    winner_intra_id = serializers.CharField(source="winner.intra_id")
-    loser_intra_id = serializers.CharField(source="loser.intra_id")
+    player1_user = UsersSerializer(source="player1")
+    player2_user = UsersSerializer(source="player2")
 
     class Meta:
         model = GeneralGameLogs
@@ -48,30 +66,35 @@ class GeneralGameLogsListSerializer(serializers.ModelSerializer):
             "game_id",
             "start_time",
             "end_time",
-            "winner_intra_id",
-            "loser_intra_id",
-            "user_request",
+            "player1_user",
+            "player2_user",
         )
+
+    def create(self, validated_data):
+        return create_game_log(validated_data)
 
 
 class TournamentGameLogsSerializer(serializers.ModelSerializer):
-    user_request = UsersSerializer(many=True, read_only=True)
+    player1_intra_id = serializers.CharField(source="player1.intra_id")
+    player2_intra_id = serializers.CharField(source="player2.intra_id")
 
     class Meta:
         model = TournamentGameLogs
         fields = (
             "tournament_name",
             "round",
-            "winner",
-            "loser",
+            "player1_intra_id",
+            "player2_intra_id",
             "start_time",
             "end_time",
             "is_final",
-            "user_request",
         )
 
+    def create(self, validated_data):
+        return create_game_log(validated_data, is_general=False)
+
     def validate(self, data):
-        if data["winner"] == data["loser"]:
+        if data["player1"] == data["player2"]:
             raise serializers.ValidationError("Winner and loser must be different.")
         # 시작 시간이 끝나는 시간보다 이전인지 확인
         if data["start_time"] >= data["end_time"]:
@@ -86,19 +109,20 @@ class TournamentGameLogsSerializer(serializers.ModelSerializer):
 
 
 class TournamentGameLogsListSerializer(serializers.ModelSerializer):
-    user_request = UsersSerializer(many=True, read_only=True)
-    winner_intra_id = serializers.CharField(source="winner.intra_id")
-    loser_intra_id = serializers.CharField(source="loser.intra_id")
+    player1_user = UsersSerializer(source="player1")
+    player2_user = UsersSerializer(source="player2")
 
     class Meta:
         model = TournamentGameLogs
         fields = (
             "tournament_name",
             "round",
-            "winner_intra_id",
-            "loser_intra_id",
+            "player1_user",
+            "player2_user",
             "start_time",
             "end_time",
             "is_final",
-            "user_request",
         )
+
+    def create(self, validated_data):
+        return create_game_log(validated_data, is_general=False)

--- a/back/games/tests.py
+++ b/back/games/tests.py
@@ -30,6 +30,8 @@ class GeneralGameLogsViewSetTest(APITestCase):
             "end_time": "2021-01-01T01:00:00Z",
             "player1_intra_id": self.user1.intra_id,
             "player2_intra_id": self.user2.intra_id,
+            "player1_score": 5,
+            "player2_score": 3,
         }
         response = self.client.post(self.create_url, data)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -46,6 +48,8 @@ class GeneralGameLogsViewSetTest(APITestCase):
             "end_time": self.end_time,
             "player1_intra_id": player1,
             "player2_intra_id": player2,
+            "player1_score": 5,
+            "player2_score": 3,
         }
         response = self.client.post(self.create_url, data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -69,6 +73,8 @@ class GeneralGameLogsViewSetTest(APITestCase):
             "end_time": self.end_time,
             "player1_intra_id": player1,
             "player2_intra_id": player2,
+            "player1_score": 5,
+            "player2_score": 3,
         }
         response = self.client.post(self.create_url, data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -85,6 +91,8 @@ class GeneralGameLogsViewSetTest(APITestCase):
             "end_time": self.start_time,
             "player1_intra_id": player1,
             "player2_intra_id": player2,
+            "player1_score": 5,
+            "player2_score": 3,
         }
         response = self.client.post(self.create_url, data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -102,6 +110,8 @@ class GeneralGameLogsViewSetTest(APITestCase):
             "end_time": datetime.now() + timedelta(hours=2),
             "player1_intra_id": player1,
             "player2_intra_id": player2,
+            "player1_score": 5,
+            "player2_score": 3,
         }
         response = self.client.post(self.create_url, data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -118,6 +128,8 @@ class GeneralGameLogsViewSetTest(APITestCase):
             "end_time": self.end_time,
             "player1_intra_id": player1,
             "player2_intra_id": player2,
+            "player1_score": 5,
+            "player2_score": 3,
         }
         response = self.client.post(self.create_url, data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -132,6 +144,24 @@ class GeneralGameLogsViewSetTest(APITestCase):
         self.assertEqual(response.data[0]["end_time"], self.end_time.isoformat())
         self.assertEqual(response.data[0]["player1_user"]["intra_id"], player1)
         self.assertEqual(response.data[0]["player2_user"]["intra_id"], player2)
+
+    def test_score_minus(self):
+        """
+        점수가 음수일 때 테스트
+        """
+        self.client.force_authenticate(user=self.user1)
+        player1 = self.user1.intra_id
+        player2 = self.user2.intra_id
+        data = {
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "player1_intra_id": player1,
+            "player2_intra_id": player2,
+            "player1_score": -1,
+            "player2_score": 3,
+        }
+        response = self.client.post(self.create_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
 class TournamentGameLogsViewSetTest(APITestCase):
@@ -156,6 +186,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
             "round": 1,
             "player1_intra_id": self.user1.intra_id,
             "player2_intra_id": self.user2.intra_id,
+            "player1_score": 5,
+            "player2_score": 3,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "is_final": False,
@@ -174,6 +206,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
             "round": 1,
             "player1_intra_id": self.user1.intra_id,
             "player2_intra_id": self.user2.intra_id,
+            "player1_score": 5,
+            "player2_score": 3,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "is_final": False,
@@ -204,6 +238,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
             "round": 1,
             "player1_intra_id": self.user1.intra_id,
             "player2_intra_id": self.user1.intra_id,
+            "player1_score": 5,
+            "player2_score": 3,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "is_final": False,
@@ -222,6 +258,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
             "round": 1,
             "player1_intra_id": self.user1.intra_id,
             "player2_intra_id": self.user2.intra_id,
+            "player1_score": 5,
+            "player2_score": 3,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "is_final": False,
@@ -234,6 +272,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
             "round": 2,
             "player1_intra_id": self.user3.intra_id,
             "player2_intra_id": self.user4.intra_id,
+            "player1_score": 5,
+            "player2_score": 3,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "is_final": False,
@@ -246,6 +286,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
             "round": 3,
             "player1_intra_id": self.user3.intra_id,
             "player2_intra_id": self.user1.intra_id,
+            "player1_score": 5,
+            "player2_score": 3,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "is_final": True,
@@ -263,6 +305,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
             "round": 1,
             "player1_intra_id": self.user1.intra_id,
             "player2_intra_id": self.user2.intra_id,
+            "player1_score": 5,
+            "player2_score": 3,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "is_final": False,
@@ -275,6 +319,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
             "round": 1,
             "player1_intra_id": self.user3.intra_id,
             "player2_intra_id": self.user4.intra_id,
+            "player1_score": 5,
+            "player2_score": 3,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "is_final": False,
@@ -293,6 +339,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
             "round": 1,
             "player1_intra_id": self.user1.intra_id,
             "player2_intra_id": self.user2.intra_id,
+            "player1_score": 5,
+            "player2_score": 3,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "is_final": False,
@@ -305,6 +353,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
             "round": 2,
             "player1_intra_id": self.user3.intra_id,
             "player2_intra_id": self.user4.intra_id,
+            "player1_score": 5,
+            "player2_score": 3,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "is_final": False,
@@ -317,6 +367,8 @@ class TournamentGameLogsViewSetTest(APITestCase):
             "round": 3,
             "player1_intra_id": self.user3.intra_id,
             "player2_intra_id": self.user1.intra_id,
+            "player1_score": 5,
+            "player2_score": 3,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "is_final": True,
@@ -346,3 +398,22 @@ class TournamentGameLogsViewSetTest(APITestCase):
         assert len(response.data) == 2
         self.assertEqual(1, response.data[0]["round"])
         self.assertEqual(3, response.data[1]["round"])
+
+    def test_score_minus(self):
+        """
+        점수가 음수일 때 테스트
+        """
+        self.client.force_authenticate(user=self.user1)
+        data = {
+            "tournament_name": self.tournament_name,
+            "round": 1,
+            "player1_intra_id": self.user1.intra_id,
+            "player2_intra_id": self.user2.intra_id,
+            "player1_score": -5,
+            "player2_score": 3,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "is_final": False,
+        }
+        response = self.client.post(self.create_log, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/back/games/urls.py
+++ b/back/games/urls.py
@@ -5,18 +5,28 @@ from . import views
 urlpatterns = [
     path(
         "general_game_logs/",
-        views.GeneralGameLogsViewSet.as_view({"get": "list", "post": "create"}),
+        views.GeneralGameLogsViewSet.as_view({"post": "create"}),
         name="general_game_logs",
     ),
     path(
-        "general_game_logs/<str:intra_id>/",
+        "general_game_logs/all/",
         views.GeneralGameLogsListViewSet.as_view({"get": "list"}),
-        name="general_game_logs_detail",
+        name="general_game_all_logs",
+    ),
+    path(
+        "general_game_logs/users/<str:intra_id>/",
+        views.GeneralGameLogsListViewSet.as_view({"get": "list"}),
+        name="general_game_user_logs",
     ),
     path(
         "tournament_game_logs/",
-        views.TournamentGameLogsViewSet.as_view({"get": "list", "post": "create"}),
+        views.TournamentGameLogsViewSet.as_view({"post": "create"}),
         name="create_tournament_game_logs",
+    ),
+    path(
+        "tournament_game_logs/all/",
+        views.TournamentGameLogsListViewSet.as_view({"get": "list"}),
+        name="tournament_game_all_logs",
     ),
     path(
         "tournament_game_logs/users/<str:intra_id>/",

--- a/back/games/views.py
+++ b/back/games/views.py
@@ -92,7 +92,6 @@ class GeneralGameLogsListViewSet(viewsets.ModelViewSet):
     serializer_class = GeneralGameLogsListSerializer
 
     def list(self, request, *args, **kwargs):
-        # 밑에 if문은 debug를 위한 임시 get
         if "intra_id" not in kwargs:
             return super().list(request, *args, **kwargs)
 
@@ -133,7 +132,6 @@ class TournamentGameLogsListViewSet(viewsets.ModelViewSet):
     serializer_class = TournamentGameLogsListSerializer
 
     def list(self, request, *args, **kwargs):
-        # 밑에 if문은 debug를 위한 임시 get
         if "intra_id" not in kwargs and "name" not in kwargs:
             return super().list(request, *args, **kwargs)
 

--- a/back/games/views.py
+++ b/back/games/views.py
@@ -49,15 +49,15 @@ def create_with_intra_id_convert_to_user_id(self, request):
     """
     intra_id를 user_id로 변환하여 Game Log를 생성
     """
-    winner_intra_id = request.data.get("winner")
-    loser_intra_id = request.data.get("loser")
+    player1_intra_id = request.data.get("player1_intra_id")
+    player2_intra_id = request.data.get("player2_intra_id")
 
-    winner_user = get_user_from_intra_id_or_user_id(winner_intra_id)
-    loser_user = get_user_from_intra_id_or_user_id(loser_intra_id)
+    player1_user = get_user_from_intra_id_or_user_id(player1_intra_id)
+    player2_user = get_user_from_intra_id_or_user_id(player2_intra_id)
 
     request_copy_data = request.data.copy()
-    request_copy_data["winner"] = winner_user.user_id
-    request_copy_data["loser"] = loser_user.user_id
+    request_copy_data["player1"] = player1_user.user_id
+    request_copy_data["player2"] = player2_user.user_id
 
     serializer = self.get_serializer(data=request_copy_data)
     serializer.is_valid(raise_exception=True)
@@ -70,7 +70,7 @@ class GeneralGameLogsViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
     queryset = GeneralGameLogs.objects.all()
     serializer_class = GeneralGameLogsSerializer
-    http_method_names = ["get", "post"]  # TODO debug를 위해 get 임시 추가
+    http_method_names = ["post"]
 
     # general game logs 생성 시 join general game 생성하는 오버라이딩 에러 발생
     # fk는 uuid가 아닌 인스턴스를 요구해서 생긴 에러인듯
@@ -102,7 +102,9 @@ class GeneralGameLogsListViewSet(viewsets.ModelViewSet):
                 {"error": "유저가 존재하지 않습니다."},
                 status=status.HTTP_404_NOT_FOUND,
             )
-        queryset = self.queryset.filter(Q(winner=user.user_id) | Q(loser=user.user_id))
+        queryset = self.queryset.filter(
+            Q(player1=user.user_id) | Q(player2=user.user_id)
+        )
         serializer = self.serializer_class(queryset, many=True)
         return Response(serializer.data)
 
@@ -111,7 +113,7 @@ class TournamentGameLogsViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
     queryset = TournamentGameLogs.objects.all()
     serializer_class = TournamentGameLogsSerializer
-    http_method_names = ["get", "post"]  # TODO debug를 위해 get 임시 추가
+    http_method_names = ["post"]
 
     def create(self, request, *args, **kwargs):
         try:
@@ -143,7 +145,7 @@ class TournamentGameLogsListViewSet(viewsets.ModelViewSet):
                     status=status.HTTP_404_NOT_FOUND,
                 )
             queryset = self.queryset.filter(
-                Q(winner=user.user_id) | Q(loser=user.user_id)
+                Q(player1=user.user_id) | Q(player2=user.user_id)
             )
         elif "name" in kwargs and "intra_id" not in kwargs:
             queryset = self.queryset.filter(tournament_name=kwargs["name"])


### PR DESCRIPTION
### Summary

1. Join 모델 삭제
2. winner, loser -> player1, player2로 변경
3. game log 관련 api에서 User의 정보가 모두 나오도록 변경
4. player1_score, player2_score 추가
5. game log 관련 url 변경

---

### Describe

#### 1. `Join 모델` 삭제
- 현재, game_log들에서 Q를 사용하여 직접 필터하여 정보를 제공하고 있습니다.
- 그렇기 때문에 가운데 Join 관련 테이블이 필요치 않기에 삭제했습니다.

#### 2. `winner` , `loser` -> `player1` , `player2` 변경
- 승자 패자가 아니라 플레이어 목록으로 필드와 test를 변경했습니다.

#### 3. User의 정보가 모두 나오도록 변경
- serializers에서 `UsersSerializer` 와 `create_game_log` 함수로 정보가 모두 나오도록 변경했습니다.

#### 4. player1_score, player2_score 추가
- 필드를 추가했습니다.
- `validate` 함수에 음수값을 판별하는 로직을 추가했습니다.

#### 5. game log 관련 url 변경

##### 5.1 `general_game_logs/`
- method: `POST`
- 비고
  - 요구하는 필드가 변경된 정보에 따라 변경되었습니다.

##### 5.2 `general_game_logs/all/`
- method: `GET`
- 비고
  - 전체 게임 로그로 올라옵니다.
  - 게임 시작 시간으로 내림차순 정렬됩니다.

##### 5.3 `tournament_game_logs/`
- method: `POST`
- 비고
  - 요구하는 필드가 변경된 정보에 따라 변경되었습니다.

##### 5.4 `tournament_game_logs/all/`
- method: `GET`
- 비고
  - 전체 게임 로그로 올라옵니다.
  - 게임 시작 시간으로 내림차순 정렬됩니다.