### PR TITLE
[Back-29] websocket for users status

### DIFF
--- a/back/back/asgi.py
+++ b/back/back/asgi.py
@@ -1,16 +1,24 @@
-"""
-ASGI config for back project.
-
-It exposes the ASGI callable as a module-level variable named ``application``.
-
-For more information on this file, see
-https://docs.djangoproject.com/en/4.1/howto/deployment/asgi/
-"""
-
 import os
 
+from channels.auth import AuthMiddlewareStack
+from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.security.websocket import AllowedHostsOriginValidator
 from django.core.asgi import get_asgi_application
+
+from pong_game.routing import websocket_urlpatterns
+
+import pong_game.routing
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "back.settings")
 
-application = get_asgi_application()
+django_asgi_app = get_asgi_application()
+
+
+application = ProtocolTypeRouter(
+    {
+        "http": django_asgi_app,
+        "websocket": AllowedHostsOriginValidator(
+            AuthMiddlewareStack(URLRouter(websocket_urlpatterns))
+        ),
+    }
+)

--- a/back/back/settings.py
+++ b/back/back/settings.py
@@ -36,6 +36,8 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
+    # Daphne must be listed before django.contrib.staticfiles in INSTALLED_APPS. error
+    "daphne",
     "django.contrib.staticfiles",
     # Third-party apps
     "corsheaders",
@@ -47,6 +49,7 @@ INSTALLED_APPS = [
     "accounts",
     "games",
     "friendrequests",
+    "pong_game",
 ]
 
 MIDDLEWARE = [
@@ -190,3 +193,6 @@ MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 MEDIA_URL = "/media/"
 
 AUTH_USER_MODEL = "accounts.Users"
+
+# Daphne
+ASGI_APPLICATION = "back.asgi.application"

--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -1,0 +1,21 @@
+from channels.generic.websocket import AsyncWebsocketConsumer
+from channels.db import database_sync_to_async
+from accounts.models import Users, UserStatusEnum
+
+
+class LoginConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        self.user = self.scope["user"]
+        if self.user.is_authenticated:
+            await self.accept()
+            await self.update_user_status(self.user, UserStatusEnum.ONLINE)
+        else:
+            await self.close()
+
+    async def disconnect(self, close_code):
+        if self.user.is_authenticated:
+            await self.update_user_status(self.user, UserStatusEnum.OFFLINE)
+
+    @database_sync_to_async
+    def update_user_status(self, user, status):
+        Users.objects.filter(user_id=user.user_id).update(status=status)

--- a/back/pong_game/routing.py
+++ b/back/pong_game/routing.py
@@ -1,0 +1,10 @@
+# chat/routing.py
+from django.urls import re_path, path
+
+from . import consumers
+
+
+websocket_urlpatterns = [
+    # re_path(r"ws/chat/(?P<room_name>\w+)/$", consumers.ChatConsumer.as_asgi()),
+    path("ws/login/", consumers.LoginConsumer.as_asgi()),
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ dj-rest-auth
 python-dotenv
 django-cors-headers
 drf-yasg
+daphne
+channels


### PR DESCRIPTION
### Summary
- ws/login/으로 접속하면 유저의 status 변경 로직 생성했습니다.
- websocket 적용함에 따라서 설정파일 추가했습니다.
### Describe
#### ws/login/으로 접속하면 유저의 status 변경 로직 생성했습니다.
- 유저의 실시간 상태를 체크 하기 위해서 websocket를 도입했습니다.
- ws/login/으로 websocket이 연결이 되면 유저의 status를 online으로 연결이 끊어지면 offline으로 변경합니다.
#### websocket 적용함에 따라서 설정파일 추가했습니다.
- [Django Channels의 튜토리얼](https://channels.readthedocs.io/en/latest/tutorial/index.html)를 참고했습니다.
- settings.py의 INSTALLED_APPS의 순서가 django app 그 다음에 Third-party apps입니다.
- 하지만 Third-party apps의 Daphne가 에러(Daphne must be listed before django.contrib.staticfiles in INSTALLED_APPS)가 발생해서 daphne 위치만 수정했습니다. 
### TODO
- websocket을 처음 도입하다보니 튜토리얼의 대부분을 따라했습니다.(추후 프로젝트에 맞게 수정및 추가가 필요합니다.)
- 다만 접속한 유저의 status만 바꾸는 간단한 로직이다보니 추후 channels Layers 같은 설정을 추가가 필요합니다. 
- 관련된 테스트도 추가할 수 있으면 좋을것 같습니다.