### PR TITLE
[Back-31] create general game consumer

### DIFF
--- a/back/back/settings.py
+++ b/back/back/settings.py
@@ -196,3 +196,12 @@ AUTH_USER_MODEL = "accounts.Users"
 
 # Daphne
 ASGI_APPLICATION = "back.asgi.application"
+
+CHANNEL_LAYERS = {
+    "default": {
+        "BACKEND": "channels_redis.core.RedisChannelLayer",
+        "CONFIG": {
+            "hosts": [("channels", 6379)],
+        },
+    },
+}

--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -19,3 +19,25 @@ class LoginConsumer(AsyncWebsocketConsumer):
     @database_sync_to_async
     def update_user_status(self, user, status):
         Users.objects.filter(user_id=user.user_id).update(status=status)
+
+
+class GeneralGameConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        self.user = self.scope["user"]
+        if self.user.is_authenticated:
+            self.game_id = self.scope["url_route"]["kwargs"]["game_id"]
+            self.game_group_name = f"game_{self.game_id}"
+            await self.channel_layer.group_add(self.game_group_name, self.channel_name)
+            await self.accept()
+        else:
+            await self.close()
+
+    async def disconnect(self, close_code):
+        if self.user.is_authenticated:
+            await self.channel_layer.group_discard(
+                self.game_group_name, self.channel_name
+            )
+
+    async def receive(self, text_data):
+        # 게임 로직 추가 필요
+        pass

--- a/back/pong_game/routing.py
+++ b/back/pong_game/routing.py
@@ -1,10 +1,10 @@
 # chat/routing.py
-from django.urls import re_path, path
+from django.urls import path
 
 from . import consumers
 
 
 websocket_urlpatterns = [
-    # re_path(r"ws/chat/(?P<room_name>\w+)/$", consumers.ChatConsumer.as_asgi()),
+    path("ws/general_game/<uuid:game_id>/", consumers.GeneralGameConsumer.as_asgi()),
     path("ws/login/", consumers.LoginConsumer.as_asgi()),
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,4 +20,7 @@ services:
       - .env_sample
     depends_on:
       - db
-      
+  channels:
+    image: redis
+    ports:
+      - "6379:6379"

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ django-cors-headers
 drf-yasg
 daphne
 channels
+channels-redis


### PR DESCRIPTION
### Summary
- channel_layers에 맞는 기본 환경 추가 했습니다.
- general_game에 대한 기본적인 웹소켓 뼈대 추가 했습니다.
### Describe
#### channel_layers에 맞는 기본 환경 추가 했습니다.
- channels에 기본 제공되는 layer는 redis를 기본으로 합니다.
- 그에 맞게 redis를 docker compose에 추가, settings.py에 CHANNEL_LAYERS 세팅, requirements.txt에  channels-redis를 추가했습니다.
#### general_game에 대한 기본적인 웹소켓 뼈대 추가 했습니다.
- 아직 게임 로직이 정해지지 않아서 기본적인 웹소켓 뼈대만 추가 했습니다.
- url로 부터 uuid인 game_id를 받아와서 channel_layer 그룹에 추가하는것 까지 했습니다.
### TODO
#### 환경 관련
- redis를 사용하는것에 대한 고민이 필요합니다.
#### general_game 관련
- 추후 게임 로직에 따라 많은것들이 추가 되어야 합니다.