### PR TITLE
[BACK-30] create-game-wait-consumer

### DIFF
--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -31,7 +31,7 @@ class GeneralGameWaitConsumer(AsyncWebsocketConsumer):
         if self.user.is_authenticated and await self.add_wait_list():
             await self.accept()
             if len(GeneralGameWaitConsumer.wait_list) > 1:
-                await GeneralGameWaitConsumer.wait_queue()
+                await GeneralGameWaitConsumer.game_match()
         else:
             await self.close()
 
@@ -45,7 +45,7 @@ class GeneralGameWaitConsumer(AsyncWebsocketConsumer):
                 GeneralGameWaitConsumer.wait_list.remove(self)
 
     @classmethod
-    async def wait_queue(cls):
+    async def game_match(cls):
         data = '{"game_id": ' + f'"{str(uuid.uuid4())}"' + "}"
         player1 = GeneralGameWaitConsumer.wait_list.popleft()
         player2 = GeneralGameWaitConsumer.wait_list.popleft()

--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -1,6 +1,10 @@
+import asyncio
+import uuid
+
 from channels.generic.websocket import AsyncWebsocketConsumer
 from channels.db import database_sync_to_async
 from accounts.models import Users, UserStatusEnum
+from collections import deque
 
 
 class LoginConsumer(AsyncWebsocketConsumer):
@@ -19,3 +23,36 @@ class LoginConsumer(AsyncWebsocketConsumer):
     @database_sync_to_async
     def update_user_status(self, user, status):
         Users.objects.filter(user_id=user.user_id).update(status=status)
+
+
+class GeneralGameWaitConsumer(AsyncWebsocketConsumer):
+    intra_id_list, wait_list = set(), deque()
+
+    async def connect(self):
+        self.user = self.scope["user"]
+        if self.user.is_authenticated and await self.add_wait_list(self):
+            await self.accept()
+            await self.wait_queue()
+        else:
+            await self.close()
+
+    @classmethod
+    async def wait_queue(cls):
+        while True:
+            if len(cls.wait_list) > 1:
+                game_id = str(uuid.uuid4())
+                player1 = cls.wait_list.popleft()
+                player2 = cls.wait_list.popleft()
+                await player1.send(game_id)
+                await player2.send(game_id)
+                cls.intra_id_list.remove(player1.user.intra_id)
+                cls.intra_id_list.remove(player2.user.intra_id)
+            await asyncio.sleep(1)
+
+    @classmethod
+    async def add_wait_list(cls, self):
+        if self.user.intra_id in cls.intra_id_list:
+            return False
+        cls.wait_list.append(self)
+        cls.intra_id_list.add(self.user.intra_id)
+        return True

--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -30,12 +30,10 @@ class GeneralGameWaitConsumer(AsyncWebsocketConsumer):
         self.user = self.scope["user"]
         if self.user.is_authenticated and await self.add_wait_list():
             await self.accept()
+            if len(GeneralGameWaitConsumer.wait_list) > 1:
+                await GeneralGameWaitConsumer.wait_queue()
         else:
             await self.close()
-
-    async def receive(self, text_data):
-        if len(GeneralGameWaitConsumer.wait_list) > 1:
-            await GeneralGameWaitConsumer.wait_queue()
 
     async def disconnect(self, close_code):
         if self.user.is_authenticated:

--- a/back/pong_game/routing.py
+++ b/back/pong_game/routing.py
@@ -7,4 +7,5 @@ from . import consumers
 websocket_urlpatterns = [
     # re_path(r"ws/chat/(?P<room_name>\w+)/$", consumers.ChatConsumer.as_asgi()),
     path("ws/login/", consumers.LoginConsumer.as_asgi()),
+    path("ws/game/wait/", consumers.GeneralGameWaitConsumer.as_asgi()),
 ]

--- a/back/pong_game/routing.py
+++ b/back/pong_game/routing.py
@@ -7,5 +7,5 @@ from . import consumers
 websocket_urlpatterns = [
     path("ws/general_game/<uuid:game_id>/", consumers.GeneralGameConsumer.as_asgi()),
     path("ws/login/", consumers.LoginConsumer.as_asgi()),
-    path("ws/game/wait/", consumers.GeneralGameWaitConsumer.as_asgi()),
+    path("ws/general_game/wait/", consumers.GeneralGameWaitConsumer.as_asgi()),
 ]


### PR DESCRIPTION
### Summary

- general game wait 요청이 들어왔을 때 동작을 구현했습니다.


### Describe

#### `GeneralGameWaitConsumer`

##### class method

- wait_list에는 빼서 메세지를 보내는 동작을 위해 `self` 객체 자체를 집어넣었습니다.
- 이때, 같은 유저가 여러번 웹소켓 연결 요청을 하면 다른 객체로 인식 됩니다. 예를 들어 같은 세션id로 postman을 이용해 두 번 웹소켓 연결 요청을 하면 self.user는 같지만 self는 다른 객체입니다.
- 그렇기에 intra_id_list를 두어 동일한 유저가 두 번 요청하지 못하도록 하였습니다.
   
##### `add_wait_list(self)`

- 이미 접속한 유저가 아니라면 wait_list와 intra_id_list에 추가하고 `True` 를 반환합니다.
- 만약 이미 접속한 유저라면 어떠한 동작없이 `False` 를 반환합니다.


##### `game_match(cls)`

- wait_list에서 가장 앞에 있는 두 유저한테 생성된 game_id를 전송하고 wait_list, intra_id_list에서 제거한다.


##### `connect`

- `add_wait_list` 함수 실행 후, 유효한 요청이라면 wait_list에 2명 이상인지 확인 후 `game_match` 함수를 실행합니다.
- 만약 인증이 없는 유저일 경우 바로 종료시킨다.

##### `disconnect`

- 인증이 된 유저 중, 현재 wait_list와 intra_id_list에 있는 유저라면 삭제하고 종료시킨다.


### TODO
- 현재 wait_list에 있는 유저가 다시 접속했을 때도 403에러를 반환합니다. 중복이라고 명시해주는 에러를 보내면 더 좋을 것 같습니다.
   
