### PR TITLE
[Back-32] test case socket

### DIFF
--- a/back/back/settings.py
+++ b/back/back/settings.py
@@ -126,13 +126,7 @@ DATABASES = {
         "PORT": 5432,
     }
 }
-# sqlite3 for test
-# DATABASES = {
-#     "default": {
-#         "ENGINE": "django.db.backends.sqlite3",
-#         "NAME": BASE_DIR / "db.sqlite3",
-#     }
-# }
+
 
 # postgresql for local development
 # DATABASES = {

--- a/back/back/test_settings.py
+++ b/back/back/test_settings.py
@@ -1,0 +1,8 @@
+from back.settings import *
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
+    }
+}

--- a/back/pong_game/tests.py
+++ b/back/pong_game/tests.py
@@ -1,0 +1,55 @@
+from back.asgi import (
+    application,
+)
+
+from django.test import TestCase
+from channels.testing import WebsocketCommunicator
+from django.contrib.auth import get_user_model
+from channels.db import database_sync_to_async
+from accounts.models import Users, UserStatusEnum
+
+
+class LoginConsumerTests(TestCase):
+    @database_sync_to_async
+    def create_test_user(self, intra_id):
+        # 테스트 사용자 생성
+        return get_user_model().objects.create_user(intra_id=intra_id)
+
+    @database_sync_to_async
+    def delete_test_user(self, user):
+        # 테스트 사용자 삭제
+        user.delete()
+
+    @database_sync_to_async
+    def get_user_status(self, user):
+        # 데이터베이스에서 사용자 상태 조회
+        return Users.objects.get(user_id=user.user_id).status
+
+    async def test_authenticated_user_connection(self):
+        """
+        인증된 유저의 경우 접속 테스트
+        """
+        self.user = await self.create_test_user(intra_id="1")
+        communicator = WebsocketCommunicator(application, "/ws/login/")
+        # user 인증
+        communicator.scope["user"] = self.user
+
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+
+        user_status = await self.get_user_status(self.user)
+        self.assertEqual(user_status, UserStatusEnum.ONLINE)
+
+        # 연결 해제 및 상태 확인
+        await communicator.disconnect()
+        user_status = await self.get_user_status(self.user)
+        self.assertEqual(user_status, UserStatusEnum.OFFLINE)
+
+    async def test_unauthenticated_user_connection(self):
+        """
+        인증이 되지 않는 유저의 경우 접속 테스트
+        """
+        communicator = WebsocketCommunicator(application, "/ws/login/")
+
+        connected, _ = await communicator.connect()
+        self.assertFalse(connected)

--- a/makefile
+++ b/makefile
@@ -7,6 +7,9 @@ debug:
 down:
 	docker-compose -f ./docker-compose.yml down
 
+test:
+	cd ./back/ && python manage.py test --settings=back.test_settings
+
 re: down
 	docker-compose -f ./docker-compose.yml up --build --detach
 
@@ -28,4 +31,4 @@ linux-fclean:
 	docker system prune --all --force --volumes
 
 
-.PHONY: all down re clean
+.PHONY: all down re clean debug test


### PR DESCRIPTION
### Summary
- make test하면 test 되도록 makefile 수정했습니다.
- socket에 대한 테스트 환경을 구축했습니다.
### Describe
#### make test하면 test 되도록 makefile 수정했습니다.
- test 하기전 setting의 db를 local로 수정해야하는 불편함이 있었습니다.
- mange.py test의 settings옵션을 통해 test를 할때는 test_settings.py를 참고하도록 수정했습니다.
- 이런 명령어를 조합해서 make test하면 test 되도록 make file에 명령어를 추가했습니다.
#### socket에 대한 테스트 환경을 구축했습니다.
- 비동기로 consumer들이 만들어져서 테스트도 기존 model과 다르게 몇가지 수정했습니다.
- 기존 테스트랑 다른것은 [gist](https://gist.github.com/guune/c1231a2b275f1029ca8e70fcff39c06a) 참고 바랍니다.

#### TODO
- 단순히 비동기 테스트에 대한 뼈대를 만드는게 목적이라서 나머지 consumer에 대한 테스트 추가가 필요합니다.

