### PR TITLE
[BACK-38] 테스트용 계정들을 간단한 url로 로그인 하는 기능을 추가 했습니다.

### DIFF
--- a/back/accounts/models.py
+++ b/back/accounts/models.py
@@ -41,6 +41,7 @@ class Users(AbstractBaseUser, PermissionsMixin):
     created_time = models.DateTimeField(auto_now_add=True, editable=False)
     updated_time = models.DateTimeField(auto_now=True)
     status = models.CharField(max_length=2, choices=UserStatusEnum.choices)
+    is_test_user = models.BooleanField(default=False)
 
     is_staff = models.BooleanField(
         default=False

--- a/back/accounts/urls.py
+++ b/back/accounts/urls.py
@@ -19,4 +19,6 @@ urlpatterns = [
     path("login/", views.Login42APIView.as_view()),
     path("login/42/callback/", views.CallbackAPIView.as_view()),
     path("logout/", logout_view, name="logout"),
+    # TODO test용 삭제
+    path("login/<str:intra_id>/", views.testAccountLogin.as_view()),
 ]

--- a/back/accounts/views.py
+++ b/back/accounts/views.py
@@ -220,3 +220,25 @@ class CallbackAPIView(APIView):
 def logout_view(request):
     logout(request)
     return redirect("/")
+
+
+# TODO test 용도 삭제 해야함
+class testAccountLogin(APIView):
+
+    def get(self, request, *args, **kwargs):
+        """
+        GET method override
+        """
+        if request.user.is_authenticated:
+            return redirect(
+                f"http://127.0.0.1:8000/api/v1/users/{request.user.intra_id}/"
+            )
+        try:
+            user_instance = Users.objects.get(intra_id=kwargs["intra_id"])
+            if user_instance.is_test_user:
+                login(request, user_instance)
+                return Response({"message": "로그인 성공."}, status=200)
+            else:
+                return Response({"error": "허용되지 않는 유저입니다."}, status=403)
+        except Users.DoesNotExist:
+            return Response({"error": "사용자를 찾을 수 없습니다."}, status=404)

--- a/back/pong_game/tests.py
+++ b/back/pong_game/tests.py
@@ -167,3 +167,7 @@ class GeneralGameConsumerTests(TestCase):
         self.assertEqual(user2_second_dict["message_type"], "start")
         self.assertEqual(user2_second_dict["1p"], self.user1.intra_id)
         self.assertEqual(user2_second_dict["2p"], self.user2.intra_id)
+
+        while True:
+            user1_second_response = await communicator1.receive_from()
+            print(user1_second_response)

--- a/back/pong_game/tests.py
+++ b/back/pong_game/tests.py
@@ -167,7 +167,3 @@ class GeneralGameConsumerTests(TestCase):
         self.assertEqual(user2_second_dict["message_type"], "start")
         self.assertEqual(user2_second_dict["1p"], self.user1.intra_id)
         self.assertEqual(user2_second_dict["2p"], self.user2.intra_id)
-
-        while True:
-            user1_second_response = await communicator1.receive_from()
-            print(user1_second_response)

--- a/back/test_user.json
+++ b/back/test_user.json
@@ -17,7 +17,8 @@
       "is_staff": false,
       "is_active": true,
       "groups": [],
-      "user_permissions": []
+      "user_permissions": [],
+      "is_test_user": true
     }
   },
   {
@@ -38,7 +39,8 @@
       "is_staff": false,
       "is_active": true,
       "groups": [],
-      "user_permissions": []
+      "user_permissions": [],
+      "is_test_user": true
     }
   },
   {
@@ -59,7 +61,8 @@
       "is_staff": false,
       "is_active": true,
       "groups": [],
-      "user_permissions": []
+      "user_permissions": [],
+      "is_test_user": true
     }
   },
   {
@@ -80,7 +83,8 @@
       "is_staff": false,
       "is_active": true,
       "groups": [],
-      "user_permissions": []
+      "user_permissions": [],
+      "is_test_user": true
     }
   },
   {
@@ -101,7 +105,8 @@
       "is_staff": false,
       "is_active": true,
       "groups": [],
-      "user_permissions": []
+      "user_permissions": [],
+      "is_test_user": true
     }
   },
   {
@@ -122,7 +127,8 @@
       "is_staff": false,
       "is_active": true,
       "groups": [],
-      "user_permissions": []
+      "user_permissions": [],
+      "is_test_user": true
     }
   },
   {


### PR DESCRIPTION
### Summary
- 게임이 진행됨에따라 2명 이상의 유저에 로그인 해서 테스트를 진행해야 합니다.
- oauth를 이용해서 로그인을 하면 불편한 경우가 있어서 테스트용 계정들을 간단한 url로 로그인 하는 기능을 추가 했습니다.
### Describe
#### 테스트용 계정들을 간단한 url로 로그인 하는 기능을 추가 했습니다.
- 테스트 모델들에 한해서 간단한 url로 로그인 하는 기능을 추가 했습니다.
#### user 모델에 is_test_user 필드를 추가했습니다.
- is_test_user가 true인 경우에만 url로 로그인이 가능합니다.
### TODO
- 이거를 나중에 필요가 없어지면 삭제를 해야합니다.
- 관련된 테스트가 필요합니다.
