### PR TITLE
[Back-36] exception handling in game socket

### DIFF
--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -112,9 +112,10 @@ class GeneralGameConsumer(AsyncWebsocketConsumer):
 
     async def disconnect(self, close_code):
         if self.user.is_authenticated:
-            self.game_loop_task.cancel()
-            await self.game_loop_task  # Task 종료까지 대기
-            ACTIVE_GAMES.pop(self.game_id)
+            if self.game_id in ACTIVE_GAMES.keys():
+                ACTIVE_GAMES.pop(self.game_id)
+                self.game_loop_task.cancel()
+                await self.game_loop_task  # Task 종료까지 대기
             await self.channel_layer.group_discard(
                 self.game_group_name, self.channel_name
             )

--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -8,6 +8,9 @@ from collections import deque
 from .module.Game import GeneralGame
 from .module.GameSetValue import MAX_SCORE, PlayerStatus
 from .module.GameSetValue import MessageType
+from .module.Player import Player
+
+ACTIVE_GAMES: dict[str, GeneralGame] = {}
 
 
 class LoginConsumer(AsyncWebsocketConsumer):
@@ -66,6 +69,9 @@ class GeneralGameWaitConsumer(AsyncWebsocketConsumer):
         await player2.send(json.dumps({"game_id": game_id}))
         GeneralGameWaitConsumer.intra_id_list.remove(player1.user.intra_id)
         GeneralGameWaitConsumer.intra_id_list.remove(player2.user.intra_id)
+        ACTIVE_GAMES[game_id] = GeneralGame(
+            Player(1, player1.user.intra_id), Player(2, player2.user.intra_id)
+        )
 
     async def add_wait_list(self):
         if self.user.intra_id in GeneralGameWaitConsumer.intra_id_list:
@@ -77,8 +83,6 @@ class GeneralGameWaitConsumer(AsyncWebsocketConsumer):
 
 # TODO url game_id 유효한지? 동일한지? 확인 로직 필요?
 class GeneralGameConsumer(AsyncWebsocketConsumer):
-    active_games: dict[str, GeneralGame] = {}
-
     def __init__(self, *args, **kwargs):
         super().__init__(args, kwargs)
         self.user: Users = None
@@ -89,15 +93,19 @@ class GeneralGameConsumer(AsyncWebsocketConsumer):
     async def connect(self):
         self.user = self.scope["user"]
         if self.user.is_authenticated:
-            self.game_id = self.scope["url_route"]["kwargs"]["game_id"]
+            self.game_id = str(self.scope["url_route"]["kwargs"]["game_id"])
             self.game_group_name = f"game_{self.game_id}"
             await self.channel_layer.group_add(self.game_group_name, self.channel_name)
             await self.accept()
-            # TODO 이미 playing인데 또 들어올 경우 예외 처리 -> game_status 추가해보기(wait, ready, playing)
-            if self.game_id not in GeneralGameConsumer.active_games.keys():
-                game = GeneralGame()
-                game.set_player(self.user.intra_id)
-                GeneralGameConsumer.active_games[self.game_id] = game
+            if self.game_id not in ACTIVE_GAMES.keys():  # 없는 게임일 때
+                await self.close()
+            elif (
+                ACTIVE_GAMES[self.game_id].get_status() != PlayerStatus.WAIT
+            ):  # 게임이 대기 중이 아닐 때
+                await self.close()
+            elif (
+                ACTIVE_GAMES[self.game_id].get_player(1).intra_id == self.user.intra_id
+            ):
                 await self.send(
                     json.dumps(
                         {
@@ -107,10 +115,9 @@ class GeneralGameConsumer(AsyncWebsocketConsumer):
                         }
                     )
                 )
-            else:
-                GeneralGameConsumer.active_games[self.game_id].set_player(
-                    self.user.intra_id
-                )
+            elif (
+                ACTIVE_GAMES[self.game_id].get_player(2).intra_id == self.user.intra_id
+            ):
                 await self.send(
                     json.dumps(
                         {
@@ -120,12 +127,16 @@ class GeneralGameConsumer(AsyncWebsocketConsumer):
                         }
                     )
                 )
+            else:  # 이 게임을 배정 받은 유저가 아닐 때
+                await self.close()
         else:
             await self.close()
 
-    # TODO 게임 종료 시 active_games에서 제거 및 self.game_loop_task 종료하기
     async def disconnect(self, close_code):
         if self.user.is_authenticated:
+            self.game_loop_task.cancel()
+            await self.game_loop_task  # Task 종료까지 대기
+            ACTIVE_GAMES.pop(self.game_id)
             await self.channel_layer.group_discard(
                 self.game_group_name, self.channel_name
             )
@@ -138,8 +149,7 @@ class GeneralGameConsumer(AsyncWebsocketConsumer):
 
     async def receive(self, text_data=None, bytes_data=None):
         data = json.loads(text_data)
-        game = GeneralGameConsumer.active_games[self.game_id]
-        # TODO 이미 playing인데 또 들어올 경우 예외 처리 -> game_status 추가해보기(wait, ready, playing)
+        game = ACTIVE_GAMES[self.game_id]
         if (
             data["message_type"] == MessageType.READY.value
             and game.get_status() == PlayerStatus.WAIT
@@ -169,11 +179,9 @@ class GeneralGameConsumer(AsyncWebsocketConsumer):
             # TODO DB 저장
             pass
 
-    # TODO game 매개변수로 잘 받아오는지
     async def send_game_messages_loop(self, game: GeneralGame):
         while True:
             await asyncio.sleep(1 / 2)
-            # game = GeneralGameConsumer.active_games.get(self.game_id)
             if game.get_status() == PlayerStatus.PLAYING:
                 await self.channel_layer.group_send(
                     self.game_group_name,

--- a/back/pong_game/module/Ball.py
+++ b/back/pong_game/module/Ball.py
@@ -1,4 +1,4 @@
-from .GameSetValue import FIELD_WIDTH, BALL_SPEED_X, BALL_SPEED_Z
+from .GameSetValue import FIELD_WIDTH, BALL_SPEED_X, BALL_SPEED_Z, BALL_RADIUS
 
 
 class Ball:
@@ -6,7 +6,7 @@ class Ball:
         self.position_x: float = 0
         self.position_y: float = 0
         self.position_z: float = 0
-        self.radius: float = 20
+        self.radius: float = BALL_RADIUS
         self.speed_x: float = BALL_SPEED_X
         self.speed_z: float = BALL_SPEED_Z
 
@@ -36,8 +36,7 @@ class Ball:
         self.speed_z *= -1
 
     def protego_maxima(self) -> None:
-        self.radius += 5
-        self.speed_z += 1
+        self.speed_z += -4
 
     def get_position(self) -> tuple:
         return self.position_x, self.position_y, self.position_z

--- a/back/pong_game/module/Game.py
+++ b/back/pong_game/module/Game.py
@@ -52,7 +52,9 @@ class GeneralGame:
 
     def key_input(self, text_data: json) -> None:
         data = json.loads(text_data)
-        if data["number"] == "player1":
+        if data["input"] == "protego_maxima":
+            self.ball.protego_maxima()
+        elif data["number"] == "player1":
             self.player1.paddle_handler(data["input"])
         elif data["number"] == "player2":
             self.player2.paddle_handler(data["input"])

--- a/back/pong_game/module/Game.py
+++ b/back/pong_game/module/Game.py
@@ -5,10 +5,10 @@ from .GameSetValue import PlayerStatus, PADDLE_CORRECTION, PADDLE_WIDTH, Message
 
 
 class GeneralGame:
-    def __init__(self):
+    def __init__(self, player1: Player, player2: Player):
         self.ball: Ball = Ball()
-        self.player1: Player | None = None
-        self.player2: Player | None = None
+        self.player1: Player = player1
+        self.player2: Player = player2
         self.score1: int = 0
         self.score2: int = 0
         self.status: PlayerStatus = PlayerStatus.WAIT
@@ -143,15 +143,6 @@ class GeneralGame:
 
     def get_ball_speed(self) -> tuple:
         return self.ball.speed_x, self.ball.speed_z
-
-    def set_player(self, player_intra_id: str) -> None:
-        if self.player1 is None:
-            self.player1 = Player(1, player_intra_id)
-            return
-
-        if self.player2 is None:
-            self.player2 = Player(2, player_intra_id)
-            return
 
     def set_ready(self, number: str) -> None:
         if number == "player1":

--- a/back/pong_game/module/Game.py
+++ b/back/pong_game/module/Game.py
@@ -57,6 +57,16 @@ class GeneralGame:
         elif data["number"] == "player2":
             self.player2.paddle_handler(data["input"])
 
+    @staticmethod
+    def build_ready_json(number: int, intra_id: str) -> json:
+        return json.dumps(
+            {
+                "message_type": MessageType.READY.value,
+                "number": "player1" if number == 1 else "player2",
+                "intra_id": intra_id,
+            }
+        )
+
     def build_start_json(self) -> json:
         return json.dumps(
             {
@@ -125,11 +135,11 @@ class GeneralGame:
         elif self._is_paddle2_collision():
             self.ball.hit_ball_back(self.player2.get_paddle().get_position_x())
 
-    def get_player(self, number: int) -> Player | None:
-        if number == 1:
-            return self.player1
-        elif number == 2:
-            return self.player2
+    def get_player(self, intra_id: str) -> tuple[Player, int] | None:
+        if self.player1.intra_id == intra_id:
+            return self.player1, 1
+        elif self.player2.intra_id == intra_id:
+            return self.player2, 2
         return None
 
     def get_status(self) -> PlayerStatus:

--- a/back/pong_game/module/GameSetValue.py
+++ b/back/pong_game/module/GameSetValue.py
@@ -8,6 +8,7 @@ PADDLE_SPEED: int = 30
 PADDLE_CORRECTION: int = 5
 BALL_SPEED_X: int = 0
 BALL_SPEED_Z: int = -10
+BALL_RADIUS: int = 20
 MAX_SCORE: int = 5
 
 

--- a/back/pong_game/tests.py
+++ b/back/pong_game/tests.py
@@ -115,9 +115,27 @@ class GeneralGameConsumerTests(TestCase):
         """
         두 명 접속시 message_type 잘 보내는지 확인
         """
-        self.user1 = await self.create_test_user(intra_id="test1")
-        self.user2 = await self.create_test_user(intra_id="test2")
-        self.game_id = str(uuid.uuid4())
+        self.user1 = await self.create_test_user(intra_id="test3")
+        self.user2 = await self.create_test_user(intra_id="test4")
+
+        # 대기방 입장 및 게임 id 생성
+        communicator1 = WebsocketCommunicator(application, "/ws/general_game/wait/")
+        communicator1.scope["user"] = self.user1
+        await communicator1.connect()
+
+        communicator2 = WebsocketCommunicator(application, "/ws/general_game/wait/")
+        communicator2.scope["user"] = self.user2
+        await communicator2.connect()
+
+        user_response = await communicator1.receive_from()
+        user_response_dict = json.loads(user_response)
+        print("dict: ", user_response_dict)
+
+        await communicator1.disconnect()
+        await communicator2.disconnect()
+
+        # 게임방 입장
+        self.game_id = user_response_dict["game_id"]
         communicator1 = WebsocketCommunicator(
             application, f"/ws/general_game/{self.game_id}/"
         )

--- a/back/pong_game/tests.py
+++ b/back/pong_game/tests.py
@@ -111,6 +111,18 @@ class GeneralGameConsumerTests(TestCase):
         # 테스트 사용자 삭제
         user.delete()
 
+    async def test_wrong_game_id(self):
+        """
+        game_id가 잘못된 경우 접속 실패
+        """
+        self.user1 = await self.create_test_user(intra_id="test1")
+        communicator1 = WebsocketCommunicator(
+            application, f"/ws/general_game/{uuid.uuid4()}/"
+        )
+        communicator1.scope["user"] = self.user1
+        connected, _ = await communicator1.connect()
+        self.assertFalse(connected)
+
     async def test_authenticated_user_connection(self):
         """
         두 명 접속시 message_type 잘 보내는지 확인
@@ -129,7 +141,6 @@ class GeneralGameConsumerTests(TestCase):
 
         user_response = await communicator1.receive_from()
         user_response_dict = json.loads(user_response)
-        print("dict: ", user_response_dict)
 
         await communicator1.disconnect()
         await communicator2.disconnect()
@@ -185,3 +196,6 @@ class GeneralGameConsumerTests(TestCase):
         self.assertEqual(user2_second_dict["message_type"], "start")
         self.assertEqual(user2_second_dict["1p"], self.user1.intra_id)
         self.assertEqual(user2_second_dict["2p"], self.user2.intra_id)
+
+        await communicator1.disconnect()
+        await communicator2.disconnect()

--- a/docs/game_socket.md
+++ b/docs/game_socket.md
@@ -80,7 +80,7 @@
 {
   "message_type": "key",
   "number": "{player1 / player2}",
-  "input": "{left_press / left_release / right_press / right_release / space}",
+  "input": "{ left_press / left_release / right_press / right_release / protego_maxima }"
 }
 ```
 
@@ -114,20 +114,24 @@
 }
 ```
 
-### 10. [Back] DB 생성해서 저장
+### 10.[Back] DB 생성해서 저장
 
+- DB 저장 성공 시
 
-## 예외 상황
+```json
+{
+  "message_type": "complete"
+}
+```
 
-### 1. 연결이 끊긴 경우
+- DB 저장 실패 시
 
-- 없던 게임으로 처리
+```json
+{
+  "message_type": "error"
+}
+```
 
-### 2. 게임 중간에 연결이 끊긴 경우
+## 논의 사항
 
-- 바로 종료
-
-### 3. 아무 uuid를 가지고 접속 요청할 때
-
-- Back 로직에서 거부할 예정
 


### PR DESCRIPTION
### Summary

- `ACTIVE_GAMES` 를 전역 변수로 변경하여 대기방과 게임방에서 모두 `Game` 객체에 접근할 수 있도록 수정했습니다.
- `Game` 객체 생성 시, player1, 2 를 받도록 수정했습니다.
- 이에 따라 테스트를 수정했습니다.


### Describe

- `ACTIVE_GAMES` 가 전역변수가 되었습니다.
- 대기방에서 메세지를 보낼 때, `ACTIVE_GAMES` 에 `game_id` 를 키로 가지는 `Game` 객체를 생성하여 저장합니다.
- 게임방 소켓 접속 시, `game_id` 를 ( 가지고 없는 게임일 때 / 게임이 대기 중이 아닐 때 / player1 일 때 / player2 일 때 / 둘 다 아닐 때 ) 로 구분하여 처리합니다.
- 소켓 종료 시, loop를 종료하고 `ACTIVE_GAMES` 에서 제거합니다.

- 게임방 관련 로직을 확인하는 테스트 앞에 대기방에 접속하여 유효한 `game_id` 를 받는 로직을 추가했습니다.
