### PR TITLE
[Back-39] save game result

### DIFF
--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -6,8 +6,10 @@ from channels.db import database_sync_to_async
 from accounts.models import Users, UserStatusEnum
 from collections import deque
 from .module.Game import GeneralGame
-from .module.GameSetValue import MAX_SCORE, PlayerStatus
+from .module.GameSetValue import MAX_SCORE, PlayerStatus, GameTimeType
 from .module.GameSetValue import MessageType
+from games.serializers import GeneralGameLogsSerializer
+from rest_framework.exceptions import ValidationError
 from .module.Player import Player
 
 ACTIVE_GAMES: dict[str, GeneralGame] = {}
@@ -143,6 +145,7 @@ class GeneralGameConsumer(AsyncWebsocketConsumer):
                     },
                 )
                 game.set_status(PlayerStatus.PLAYING)
+                game.set_game_time(GameTimeType.START_TIME.value)
                 self.game_loop_task = asyncio.create_task(
                     self.send_game_messages_loop(game)
                 )
@@ -155,12 +158,27 @@ class GeneralGameConsumer(AsyncWebsocketConsumer):
             data["message_type"] == MessageType.END.value
             and game.get_status() == PlayerStatus.END
         ):
-            # TODO DB 저장
-            pass
+            try:
+                await self.save_game_data_to_db(game.get_db_data())
+                await self.send(
+                    json.dumps(
+                        {
+                            "message_type": MessageType.COMPLETE.value,
+                        }
+                    )
+                )
+            except ValidationError:
+                await self.send(
+                    json.dumps(
+                        {
+                            "message_type": MessageType.ERROR.value,
+                        }
+                    )
+                )
 
     async def send_game_messages_loop(self, game: GeneralGame):
         while True:
-            await asyncio.sleep(1 / 2)
+            await asyncio.sleep(1 / 30)
             if game.get_status() == PlayerStatus.PLAYING:
                 await self.channel_layer.group_send(
                     self.game_group_name,
@@ -178,5 +196,13 @@ class GeneralGameConsumer(AsyncWebsocketConsumer):
                         {"type": "game.message", "message": game.build_end_json()},
                     )
                     game.set_status(PlayerStatus.END)
+                    game.set_game_time(GameTimeType.END_TIME.value)
                     break
                 game.set_status(PlayerStatus.PLAYING)
+
+    @database_sync_to_async
+    def save_game_data_to_db(self, game_data: dict) -> None:
+        serializer = GeneralGameLogsSerializer(data=game_data)
+        # raise_exception=True 에러 발생시 예외처리 해야함
+        if serializer.is_valid(raise_exception=True):
+            serializer.save()

--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -117,7 +117,10 @@ class GeneralGameConsumer(AsyncWebsocketConsumer):
             if self.game_id in ACTIVE_GAMES.keys():
                 ACTIVE_GAMES.pop(self.game_id)
                 self.game_loop_task.cancel()
-                await self.game_loop_task  # Task 종료까지 대기
+                try:  # cancel() 동작이 끝날 때까지 대기
+                    await self.game_loop_task
+                except asyncio.CancelledError:
+                    pass  # task가 이미 취소된 경우
             await self.channel_layer.group_discard(
                 self.game_group_name, self.channel_name
             )

--- a/back/pong_game/module/Ball.py
+++ b/back/pong_game/module/Ball.py
@@ -1,3 +1,4 @@
+from . import GameSetValue
 from .GameSetValue import FIELD_WIDTH, BALL_SPEED_X, BALL_SPEED_Z, BALL_RADIUS
 
 
@@ -8,14 +9,15 @@ class Ball:
         self.position_z: float = 0
         self.radius: float = BALL_RADIUS
         self.speed_x: float = BALL_SPEED_X
-        self.speed_z: float = BALL_SPEED_Z
+        # test 할때 속도를 받아오기 위해서 BALL_SPEED_Z를 GameSetValue.BALL_SPEED_Z로 수정
+        self.speed_z: float = GameSetValue.BALL_SPEED_Z
 
     def reset_position(self) -> None:
         self.position_x = 0
         self.position_y = 0
         self.position_z = 0
         self.speed_x = BALL_SPEED_X
-        self.speed_z = BALL_SPEED_Z
+        self.speed_z = GameSetValue.BALL_SPEED_Z
 
     def update_ball_position(self) -> None:
         # TODO wasTouchingPaddle 들어갈 위치

--- a/back/pong_game/module/Game.py
+++ b/back/pong_game/module/Game.py
@@ -105,8 +105,8 @@ class GeneralGame:
         )
 
     def _move_paddle(self) -> None:
-        self.player1.get_paddle().move_handler()
-        self.player2.get_paddle().move_handler()
+        self.player1.get_paddle().move_handler(player_num=1)
+        self.player2.get_paddle().move_handler(player_num=2)
 
     def _move_ball(self) -> None:
         self.ball.update_ball_position()

--- a/back/pong_game/module/Game.py
+++ b/back/pong_game/module/Game.py
@@ -167,10 +167,16 @@ class GeneralGame:
         return self.ball.speed_x, self.ball.speed_z
 
     def get_game_time(self, time_type: GameTimeType) -> datetime:
-        if time_type == GameTimeType.START.value:
+        if time_type == GameTimeType.START_TIME.value:
             return self.start_time
-        elif time_type == GameTimeType.END.value:
+        elif time_type == GameTimeType.END_TIME.value:
             return self.end_time
+
+    def set_game_time(self, time_type: GameTimeType) -> None:
+        if time_type == GameTimeType.START_TIME.value:
+            self.start_time = datetime.now()
+        elif time_type == GameTimeType.END_TIME.value:
+            self.end_time = datetime.now()
 
     def get_db_data(self):
         return {

--- a/back/pong_game/module/Game.py
+++ b/back/pong_game/module/Game.py
@@ -1,7 +1,15 @@
 import json
+from datetime import datetime
+
 from .Player import Player
 from .Ball import Ball
-from .GameSetValue import PlayerStatus, PADDLE_CORRECTION, PADDLE_WIDTH, MessageType
+from .GameSetValue import (
+    PlayerStatus,
+    PADDLE_CORRECTION,
+    PADDLE_WIDTH,
+    MessageType,
+    GameTimeType,
+)
 
 
 class GeneralGame:
@@ -12,6 +20,8 @@ class GeneralGame:
         self.score1: int = 0
         self.score2: int = 0
         self.status: PlayerStatus = PlayerStatus.WAIT
+        self.start_time: datetime | None = None
+        self.end_time: datetime | None = None
 
     def is_all_ready(self) -> bool:
         if self.player1 is None or self.player2 is None:
@@ -143,6 +153,22 @@ class GeneralGame:
 
     def get_ball_speed(self) -> tuple:
         return self.ball.speed_x, self.ball.speed_z
+
+    def get_game_time(self, time_type: GameTimeType) -> datetime:
+        if time_type == GameTimeType.START.value:
+            return self.start_time
+        elif time_type == GameTimeType.END.value:
+            return self.end_time
+
+    def get_db_data(self):
+        return {
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "player1_intra_id": self.player1.intra_id,
+            "player2_intra_id": self.player2.intra_id,
+            "player1_score": self.score1,
+            "player2_score": self.score2,
+        }
 
     def set_player(self, player_intra_id: str) -> None:
         if self.player1 is None:

--- a/back/pong_game/module/GameSetValue.py
+++ b/back/pong_game/module/GameSetValue.py
@@ -34,3 +34,10 @@ class MessageType(Enum):
     PLAYING = "playing"
     SCORE = "score"
     END = "end"
+    COMPLETE = "complete"
+    ERROR = "error"
+
+
+class GameTimeType(Enum):
+    START_TIME = "start_time"
+    END_TIME = "end_time"

--- a/back/pong_game/module/Paddle.py
+++ b/back/pong_game/module/Paddle.py
@@ -33,11 +33,17 @@ class Paddle:
         elif key_input == KeyboardInput.RIGHT_RELEASE.value:
             self.right = False
 
-    def move_handler(self) -> None:
-        if self.left and not self.right:
-            self._move(-1)
-        elif not self.left and self.right:
-            self._move(1)
+    def move_handler(self, player_num: int) -> None:
+        if player_num is 1:
+            if self.left and not self.right:
+                self._move(-1)
+            elif not self.left and self.right:
+                self._move(1)
+        elif player_num is 2:
+            if self.left and not self.right:
+                self._move(1)
+            elif not self.left and self.right:
+                self._move(-1)
 
     def _move(self, direction: int) -> None:
         new_paddle_x = self.position_x + direction * PADDLE_SPEED

--- a/back/pong_game/module/Paddle.py
+++ b/back/pong_game/module/Paddle.py
@@ -16,13 +16,9 @@ class Paddle:
         self.left: bool = False
         self.right: bool = False
 
-        # TODO front 구현에 따라 필요할 수도 안 필요할 수도 있음
-        # self.direction: int = 1 if number == 1 else -1
-
     def get_position_x(self) -> float:
         return self.position_x
 
-    # TODO space 키는 프론트에서 처리 후, protego maxima 가 실행되었는지 판단하여 전달
     def input_handler(self, key_input: str) -> None:
         if key_input == KeyboardInput.LEFT_PRESS.value:
             self.left = True
@@ -34,12 +30,12 @@ class Paddle:
             self.right = False
 
     def move_handler(self, player_num: int) -> None:
-        if player_num is 1:
+        if player_num == 1:
             if self.left and not self.right:
                 self._move(-1)
             elif not self.left and self.right:
                 self._move(1)
-        elif player_num is 2:
+        elif player_num == 2:
             if self.left and not self.right:
                 self._move(1)
             elif not self.left and self.right:

--- a/back/pong_game/tests.py
+++ b/back/pong_game/tests.py
@@ -117,7 +117,7 @@ class GeneralGameConsumerTests(TestCase):
         user.delete()
 
     @database_sync_to_async
-    def get_general_game_data(self, player_num: int, player):
+    def test_get_general_game_data(self, player_num: int, player):
         try:
             if player_num == 1:
                 return GeneralGameLogs.objects.get(player1=player.user_id)
@@ -230,7 +230,7 @@ class GeneralGameConsumerTests(TestCase):
         await communicator1.disconnect()
         await communicator2.disconnect()
 
-    @patch("pong_game.module.GameSetValue.BALL_SPEED_Z", -500)
+    @patch("pong_game.module.GameSetValue.BALL_SPEED_Z", -300)
     async def test_save_game_data_to_db(self):
         """
         게임 종료시 db에 잘 저장하는지 확인

--- a/back/pong_game/tests.py
+++ b/back/pong_game/tests.py
@@ -117,7 +117,7 @@ class GeneralGameConsumerTests(TestCase):
         user.delete()
 
     @database_sync_to_async
-    def test_get_general_game_data(self, player_num: int, player):
+    def get_general_game_data(self, player_num: int, player):
         try:
             if player_num == 1:
                 return GeneralGameLogs.objects.get(player1=player.user_id)
@@ -152,7 +152,7 @@ class GeneralGameConsumerTests(TestCase):
         connected, _ = await communicator1.connect()
         self.assertFalse(connected)
 
-    async def authenticated_user_connection(self):
+    async def test_authenticated_user_connection(self):
         """
         두 명 접속시 message_type 잘 보내는지 확인
         """
@@ -236,7 +236,6 @@ class GeneralGameConsumerTests(TestCase):
         게임 종료시 db에 잘 저장하는지 확인
         공 속도는 test 할때 50배로
         """
-
         self.user1 = await self.create_test_user(intra_id="test1")
         self.user2 = await self.create_test_user(intra_id="test2")
 

--- a/back/pong_game/tests.py
+++ b/back/pong_game/tests.py
@@ -1,5 +1,8 @@
+import asyncio
 import json
 import uuid
+import time
+from unittest.mock import patch
 
 from back.asgi import (
     application,
@@ -10,6 +13,8 @@ from channels.testing import WebsocketCommunicator
 from django.contrib.auth import get_user_model
 from channels.db import database_sync_to_async
 from accounts.models import Users, UserStatusEnum
+from pong_game.module.GameSetValue import MessageType
+from games.models import GeneralGameLogs
 
 
 class LoginConsumerTests(TestCase):
@@ -69,6 +74,30 @@ class GeneralGameWaitConsumerTests(TestCase):
         # 테스트 사용자 삭제
         user.delete()
 
+    @database_sync_to_async
+    def get_general_game_data(self, player_num: int, player):
+        try:
+            if player_num == 1:
+                return GeneralGameLogs.objects.get(player1=player.user_id)
+            elif player_num == 2:
+                return GeneralGameLogs.objects.get(player2=player.user_id)
+        except GeneralGameLogs.DoesNotExist:
+            return None
+
+    # polling 형식으로 데이터 가져오기
+    async def wait_for_game_data(self, player_num: int, player, timeout=5):
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            try:
+                game_data = await self.get_general_game_data(
+                    player_num=player_num, player=player
+                )
+                if game_data:
+                    return game_data
+            except GeneralGameLogs.DoesNotExist:
+                await asyncio.sleep(0.2)
+        return None
+
     async def test_authenticated_user_connection(self):
         """
         2명 접속시 game_id, player1, 2 인트라 아이디 받는지 확인
@@ -123,7 +152,7 @@ class GeneralGameConsumerTests(TestCase):
         connected, _ = await communicator1.connect()
         self.assertFalse(connected)
 
-    async def test_authenticated_user_connection(self):
+    async def authenticated_user_connection(self):
         """
         두 명 접속시 message_type 잘 보내는지 확인
         """
@@ -197,5 +226,111 @@ class GeneralGameConsumerTests(TestCase):
         self.assertEqual(user2_second_dict["1p"], self.user1.intra_id)
         self.assertEqual(user2_second_dict["2p"], self.user2.intra_id)
 
+        # disconnect 안하면 밑에서 에러 발생
         await communicator1.disconnect()
         await communicator2.disconnect()
+
+    @patch("pong_game.module.GameSetValue.BALL_SPEED_Z", -500)
+    async def test_save_game_data_to_db(self):
+        """
+        게임 종료시 db에 잘 저장하는지 확인
+        공 속도는 test 할때 50배로
+        """
+
+        self.user1 = await self.create_test_user(intra_id="test1")
+        self.user2 = await self.create_test_user(intra_id="test2")
+
+        # 대기방 입장 및 게임 id 생성
+        communicator1 = WebsocketCommunicator(application, "/ws/general_game/wait/")
+        communicator1.scope["user"] = self.user1
+        # 접속 확인
+        connected, _ = await communicator1.connect()
+        self.assertTrue(connected)
+
+        communicator2 = WebsocketCommunicator(application, "/ws/general_game/wait/")
+        communicator2.scope["user"] = self.user2
+        # 접속 확인
+        connected, _ = await communicator2.connect()
+        self.assertTrue(connected)
+
+        user_response = await communicator1.receive_from()
+        user_response_dict = json.loads(user_response)
+
+        await communicator1.disconnect()
+        await communicator2.disconnect()
+
+        # 게임방 입장
+        self.game_id = user_response_dict["game_id"]
+        print("in test:", self.game_id)
+        communicator1 = WebsocketCommunicator(
+            application, f"/ws/general_game/{self.game_id}/"
+        )
+        communicator2 = WebsocketCommunicator(
+            application, f"/ws/general_game/{self.game_id}/"
+        )
+
+        await communicator1.send_to(
+            text_data=json.dumps(
+                {
+                    "message_type": "ready",
+                    "intra_id": "test1",
+                    "number": "player1",
+                }
+            )
+        )
+        await communicator2.send_to(
+            text_data=json.dumps(
+                {
+                    "message_type": "ready",
+                    "intra_id": "test2",
+                    "number": "player2",
+                }
+            )
+        )
+
+        # 왼쪽으로 player1 패들을 이동
+        await communicator1.send_to(
+            text_data=json.dumps(
+                {"message_type": "playing", "number": "player1", "input": "left_press"}
+            )
+        )
+
+        user1_response = await communicator1.receive_from()
+        user1_dict = json.loads(user1_response)
+        print(user1_dict)
+
+        # while True:
+        #     user1_response = await communicator1.receive_from()
+        #     user1_dict = json.loads(user1_response)
+        #     print(user1_dict)
+        #     if user1_dict["message_type"] == "end":
+        #         break
+        #
+        # # end 메세지를 consumer로 날림
+        # await communicator1.send_to(
+        #     text_data=json.dumps(
+        #         {
+        #             "message_type": "end",
+        #         }
+        #     )
+        # )
+        # user1_response = await communicator1.receive_from()
+        # user1_dict = json.loads(user1_response)
+        # self.assertEqual(user1_dict["message_type"], MessageType.COMPLETE.value)
+        #
+        # # db 저장 될 때 까지 0.2초씩 기다림 timeout은 2초
+        # game_data_from_db = await self.wait_for_game_data(
+        #     player_num=1, player=self.user1, timeout=2
+        # )
+        #
+        # # 2초동안 못받아오면 실패
+        # if game_data_from_db is None:
+        #     self.assertTrue(False)
+        #
+        # self.assertEqual(game_data_from_db.player1_id, self.user1.user_id)
+        # self.assertEqual(game_data_from_db.player2_id, self.user2.user_id)
+        # self.assertEqual(game_data_from_db.player1_score, 0)
+        # self.assertEqual(game_data_from_db.player2_score, 5)
+        #
+        # await communicator1.disconnect()
+        # await communicator2.disconnect()


### PR DESCRIPTION
### Summary
- 게임 정상 종료 시 db 저장 기능을 추가했습니다.
- 2p 패들이 키입력과 반대로 움직이는 버그 수정했습니다.
- DB 저장 기능과 관련된 test를 추가했습니다.
### Describe
#### 게임 정상 종료 시 db 저장 기능을 추가했습니다.
- 게임이 정상 종료 후 db 저장에 성공 했을 때 ＂message_type＂: ＂complete＂, 실패 했을때 message_type＂: ＂error＂를 프론트에 보내줍니다.
- general_game_log에는 시작 소요 시간과 종료 소요 시간이 필요해서 Game 모델에 start_time, end_time 변수, 관련된 get, set 메서드를 추가했습니다.
#### 2p 패들이 키입력과 반대로 움직이는 버그 수정했습니다.
- 1p, 2p 패들이 같은 로직으로 되어 있어서 move_handler 메서드에 player_num: int으로 1p, 2p를 받도록 수정했습니다.
#### DB 저장 기능과 관련된 test를 추가했습니다.
- 정상적으로 종료 시 db 저장 관련해서 test를 추가했습니다.
- 패들이 움직이지 않은 상태로 게임이 진행되면 끝나지 않기 때문에 1p 패들을 왼쪽으로 이동시키면서 게임을 시작했습니다.
##### @patch(＂pong_game.module.GameSetValue.BALL_SPEED_Z＂, -500),
- 원래 공 속도로 진행하면 테스트하는데 너무 오래 걸려서 테스트 할 때만 공 속도를 50배로 증가시켰습니다.
##### get_general_game_data(self, player_num: int, player), wait_for_game_data(self, player_num: int, player, timeout=5):
- 게임 데이터가 저장되는 것과 그것을 확인하는 테스트가 동기적으로 실행 되지 않기 때문에 2초의 타임아웃을 가지고 0.2초씩 polling 방식으로 게임 데이터가 저장되는지 확인합니다.
### TODO
- db 저장 종료 시 성공, 실패에 대한 메시지를 프론트에 보내주는데 그것을 처리하는 로직를 프론트에 구현 해야 합니다.
- 수정했습니다 상에는 게임 로직이 잘 표현 되는데 따로 데이터를 뽑아 봤을 때 player 1의 위치를 -로 지정해놨는데 반대로 되어 있는 것 같아서 수정이 필요합니다.
- db 저장 실패에 대한 테스트가 필요합니다.
