### PR TITLE
[Back-41] fix pong game logic

### DIFF
--- a/back/pong_game/module/Ball.py
+++ b/back/pong_game/module/Ball.py
@@ -1,5 +1,5 @@
 from . import GameSetValue
-from .GameSetValue import FIELD_WIDTH, BALL_SPEED_X, BALL_SPEED_Z, BALL_RADIUS
+from .GameSetValue import FIELD_WIDTH, BALL_SPEED_X, BALL_RADIUS
 
 
 class Ball:
@@ -20,8 +20,6 @@ class Ball:
         self.speed_z = GameSetValue.BALL_SPEED_Z
 
     def update_ball_position(self) -> None:
-        # TODO wasTouchingPaddle 들어갈 위치
-
         self.position_x += self.speed_x
         self.position_z += self.speed_z
         self.position_y = -((self.position_z - 1) * (self.position_z - 1) / 5000) + 435

--- a/back/pong_game/module/Game.py
+++ b/back/pong_game/module/Game.py
@@ -31,20 +31,20 @@ class GeneralGame:
         return False
 
     def _is_past_paddle1(self) -> bool:
-        return self.ball.position_z > self.player1.paddle.position_z + PADDLE_CORRECTION
+        return self.ball.position_z < self.player1.paddle.position_z - PADDLE_CORRECTION
 
     def _is_past_paddle2(self) -> bool:
-        return self.ball.position_z < self.player2.paddle.position_z - PADDLE_CORRECTION
+        return self.ball.position_z > self.player2.paddle.position_z + PADDLE_CORRECTION
 
     def _is_paddle1_collision(self) -> bool:
         return (
-            self.ball.position_z + self.ball.radius >= self.player1.paddle.position_z
+            self.ball.position_z - self.ball.radius <= self.player1.paddle.position_z
             and self._is_ball_aligned_with_paddle(1)
         )
 
     def _is_paddle2_collision(self) -> bool:
         return (
-            self.ball.position_z - self.ball.radius <= self.player2.paddle.position_z
+            self.ball.position_z + self.ball.radius >= self.player2.paddle.position_z
             and self._is_ball_aligned_with_paddle(2)
         )
 

--- a/back/pong_game/module/GameSetValue.py
+++ b/back/pong_game/module/GameSetValue.py
@@ -10,6 +10,7 @@ BALL_SPEED_X: int = 0
 BALL_SPEED_Z: int = -10
 BALL_RADIUS: int = 20
 MAX_SCORE: int = 5
+PADDLE_BOUNDARY: float = FIELD_WIDTH / 2 - PADDLE_WIDTH / 2
 
 
 class KeyboardInput(Enum):

--- a/back/pong_game/module/Paddle.py
+++ b/back/pong_game/module/Paddle.py
@@ -4,6 +4,7 @@ from .GameSetValue import (
     PADDLE_WIDTH,
     FIELD_LENGTH,
     KeyboardInput,
+    PADDLE_BOUNDARY,
 )
 
 
@@ -44,6 +45,6 @@ class Paddle:
     def _move(self, direction: int) -> None:
         new_paddle_x = self.position_x + direction * PADDLE_SPEED
         self.position_x = max(
-            -FIELD_WIDTH / 2 + PADDLE_WIDTH / 2,
-            min(FIELD_WIDTH / 2 - PADDLE_WIDTH / 2, new_paddle_x),
+            -PADDLE_BOUNDARY,
+            min(PADDLE_BOUNDARY, new_paddle_x),
         )

--- a/back/pong_game/module/Paddle.py
+++ b/back/pong_game/module/Paddle.py
@@ -11,7 +11,7 @@ class Paddle:
     def __init__(self, number: int):
         self.position_x: float = 0
         self.position_y: float = 0
-        self.position_z: float = FIELD_LENGTH / 2 if number == 1 else -FIELD_LENGTH / 2
+        self.position_z: float = -FIELD_LENGTH / 2 if number == 1 else FIELD_LENGTH / 2
 
         self.left: bool = False
         self.right: bool = False

--- a/back/pong_game/tests.py
+++ b/back/pong_game/tests.py
@@ -140,6 +140,76 @@ class GeneralGameConsumerTests(TestCase):
                 await asyncio.sleep(0.2)
         return None
 
+    async def setup_game_environment_before_start(self) -> tuple:
+        """
+        start 전까지 환경 세팅
+        """
+
+        self.user1 = await self.create_test_user(intra_id="test1")
+        self.user2 = await self.create_test_user(intra_id="test2")
+        # 대기방 입장 및 게임 id 생성
+        communicator1 = WebsocketCommunicator(application, "/ws/general_game/wait/")
+        communicator1.scope["user"] = self.user1
+        # 접속 확인
+        connected, _ = await communicator1.connect()
+        self.assertTrue(connected)
+
+        communicator2 = WebsocketCommunicator(application, "/ws/general_game/wait/")
+        communicator2.scope["user"] = self.user2
+        # 접속 확인
+        connected, _ = await communicator2.connect()
+        self.assertTrue(connected)
+
+        user_response = await communicator1.receive_from()
+        user_response_dict = json.loads(user_response)
+
+        await communicator1.disconnect()
+        await communicator2.disconnect()
+
+        # 게임방 입장
+        self.game_id = user_response_dict["game_id"]
+        communicator3 = WebsocketCommunicator(
+            application, f"/ws/general_game/{self.game_id}/"
+        )
+
+        communicator3.scope["user"] = self.user1
+        connected, _ = await communicator3.connect()
+        self.assertTrue(connected)
+
+        communicator4 = WebsocketCommunicator(
+            application, f"/ws/general_game/{self.game_id}/"
+        )
+
+        communicator4.scope["user"] = self.user2
+        connected, _ = await communicator4.connect()
+        self.assertTrue(connected)
+
+        await communicator3.send_to(
+            text_data=json.dumps(
+                {
+                    "message_type": "ready",
+                    "intra_id": "test1",
+                    "number": "player1",
+                }
+            )
+        )
+
+        await communicator4.send_to(
+            text_data=json.dumps(
+                {
+                    "message_type": "ready",
+                    "intra_id": "test2",
+                    "number": "player2",
+                }
+            )
+        )
+
+        # ready 제거
+        tmp = await communicator3.receive_from()
+        tmp = await communicator3.receive_from()
+
+        return communicator3, communicator4
+
     async def test_wrong_game_id(self):
         """
         game_id가 잘못된 경우 접속 실패
@@ -236,64 +306,7 @@ class GeneralGameConsumerTests(TestCase):
         게임 종료시 db에 잘 저장하는지 확인
         공 속도는 test 할때 50배로
         """
-        self.user1 = await self.create_test_user(intra_id="test1")
-        self.user2 = await self.create_test_user(intra_id="test2")
-
-        # 대기방 입장 및 게임 id 생성
-        communicator1 = WebsocketCommunicator(application, "/ws/general_game/wait/")
-        communicator1.scope["user"] = self.user1
-        # 접속 확인
-        connected, _ = await communicator1.connect()
-        self.assertTrue(connected)
-
-        communicator2 = WebsocketCommunicator(application, "/ws/general_game/wait/")
-        communicator2.scope["user"] = self.user2
-        # 접속 확인
-        connected, _ = await communicator2.connect()
-        self.assertTrue(connected)
-
-        user_response = await communicator1.receive_from()
-        user_response_dict = json.loads(user_response)
-
-        await communicator1.disconnect()
-        await communicator2.disconnect()
-
-        # 게임방 입장
-        self.game_id = user_response_dict["game_id"]
-        communicator1 = WebsocketCommunicator(
-            application, f"/ws/general_game/{self.game_id}/"
-        )
-
-        communicator1.scope["user"] = self.user1
-        connected, _ = await communicator1.connect()
-        self.assertTrue(connected)
-
-        communicator2 = WebsocketCommunicator(
-            application, f"/ws/general_game/{self.game_id}/"
-        )
-
-        communicator2.scope["user"] = self.user2
-        connected, _ = await communicator2.connect()
-        self.assertTrue(connected)
-
-        await communicator1.send_to(
-            text_data=json.dumps(
-                {
-                    "message_type": "ready",
-                    "intra_id": "test1",
-                    "number": "player1",
-                }
-            )
-        )
-        await communicator2.send_to(
-            text_data=json.dumps(
-                {
-                    "message_type": "ready",
-                    "intra_id": "test2",
-                    "number": "player2",
-                }
-            )
-        )
+        communicator1, communicator2 = await self.setup_game_environment_before_start()
 
         # 왼쪽으로 player1 패들을 이동
         await communicator1.send_to(
@@ -333,6 +346,94 @@ class GeneralGameConsumerTests(TestCase):
         self.assertEqual(game_data_from_db.player2_id, self.user2.user_id)
         self.assertEqual(game_data_from_db.player1_score, 0)
         self.assertEqual(game_data_from_db.player2_score, 5)
+
+        await communicator1.disconnect()
+        await communicator2.disconnect()
+
+    @patch("pong_game.module.GameSetValue.BALL_SPEED_Z", -300)
+    async def test_move_paddle_logic_1(self):
+        """
+        패들 움직임을 제대로 작동하는지 테스트
+        1. 1p 왼쪽 이동시 패들이 -인지
+        2. 2p 오른쪽 이동시 패들의 x방향이 +인지
+        3. 공이 시작시 -로 날라가는지(나중에 변경 될 수도 있음)
+        4. 1p를 왼쪽으로 움직인 상태로 고정 했을때 1p 패들과 공이 충돌하지 않는지
+        """
+
+        communicator1, communicator2 = await self.setup_game_environment_before_start()
+
+        # 왼쪽으로 player1 패들을 이동
+        await communicator1.send_to(
+            text_data=json.dumps(
+                {"message_type": "playing", "number": "player1", "input": "left_press"}
+            )
+        )
+
+        # 왼쪽으로 player2 패들을 이동
+        await communicator2.send_to(
+            text_data=json.dumps(
+                {"message_type": "playing", "number": "player2", "input": "left_press"}
+            )
+        )
+
+        while True:
+            user1_response = await communicator1.receive_from()
+            user1_dict = json.loads(user1_response)
+
+            if user1_dict["message_type"] == "playing":
+                # 1. 1p 왼쪽 이동시 1p 패들이 - 인지
+                self.assertTrue(user1_dict["paddle1"] < 0)
+                # 2. 2p 왼쪽 이동시 2p 패들이 + 인지
+                self.assertTrue(user1_dict["paddle2"] > 0)
+                # 3. 볼이 시작시 -로 이동하는지, 4. 1p와 충돌 안 하는지(충돌하면 ball_vz의 음수에서 양수가 됨)
+                self.assertTrue(user1_dict["ball_vz"] < 0)
+            if user1_dict["message_type"] == "end":
+                break
+
+        await communicator1.disconnect()
+        await communicator2.disconnect()
+
+    @patch("pong_game.module.GameSetValue.BALL_SPEED_Z", -300)
+    async def test_move_paddle_logic_2(self):
+        """
+        1. 1p 오른쪽 이동시 패들이 x방향이 +인지
+        2. 2p 왼쪽 이동시 패들의 x방향이 -인지
+        """
+
+        communicator1, communicator2 = await self.setup_game_environment_before_start()
+
+        # 왼쪽으로 player1 패들을 이동
+        await communicator1.send_to(
+            text_data=json.dumps(
+                {
+                    "message_type": "playing",
+                    "number": "player1",
+                    "input": "right_press",
+                }
+            )
+        )
+
+        # 왼쪽으로 player2 패들을 이동
+        await communicator2.send_to(
+            text_data=json.dumps(
+                {
+                    "message_type": "playing",
+                    "number": "player2",
+                    "input": "right_press",
+                }
+            )
+        )
+
+        while True:
+            user1_response = await communicator1.receive_from()
+            user1_dict = json.loads(user1_response)
+            if user1_dict["message_type"] == "playing":
+                # 1. 1p 왼쪽 이동시 1p 패들이 - 인지
+                self.assertTrue(user1_dict["paddle1"] > 0)
+                # 2. 2p 왼쪽 이동시 2p 패들이 + 인지
+                self.assertTrue(user1_dict["paddle2"] < 0)
+            if user1_dict["message_type"] == "end":
+                break
 
         await communicator1.disconnect()
         await communicator2.disconnect()

--- a/back/pong_game/tests.py
+++ b/back/pong_game/tests.py
@@ -402,7 +402,7 @@ class GeneralGameConsumerTests(TestCase):
 
         communicator1, communicator2 = await self.setup_game_environment_before_start()
 
-        # 왼쪽으로 player1 패들을 이동
+        # 오른쪽으로 player1 패들을 이동
         await communicator1.send_to(
             text_data=json.dumps(
                 {
@@ -413,7 +413,7 @@ class GeneralGameConsumerTests(TestCase):
             )
         )
 
-        # 왼쪽으로 player2 패들을 이동
+        # 오른쪽으로 player2 패들을 이동
         await communicator2.send_to(
             text_data=json.dumps(
                 {


### PR DESCRIPTION
### Summary
- game logic을 수정했습니다.
- paddle의 _move를 리팩토링 했습니다.
- 테스트에서 중복된 로직을 setup_game_environment_before_start 함수로 만들었습니다.
- 바뀐 로직을 확인하는 테스트를 추가했습니다.
### Describe
#### game logic을 수정했습니다.
- 저희가 가정한 paddle1의 z 위치는 마이너스, paddle2의 z 위치는 플러스였습니다.
- 하지만 실제로 데이터를 뽑아보니 반대로 되어 있어서 관련된 로직을 수정했습니다.
#### paddle의 _move를 리팩토링 했습니다.
- PADDLE_BOUNDARY 상수를 통해 조금 더 가독성 좋게 할 수 있을 것 같아서 수정했습니다.
#### 테스트에서 중복된 로직을 setup_game_environment_before_start 함수로 만들었습니다.
- start 하기 전까지 wait하고, ready하는 중복되는 로직이 있어서 그 로직을 함수로 뺐습니다.
#### 바뀐 로직을 확인하는 테스트를 추가했습니다.
- 저희가 가정한 paddle z위치, 공 위치를 확인하는 테스트를 추가했습니다.