### PR TITLE
[Back-44] create tournament game wait consumer

### DIFF
--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -245,10 +245,10 @@ class TournamentGameWaitConsumer(AsyncWebsocketConsumer):
 
     async def receive(self, text_data: json = None, bytes_data=None) -> None:
         data = json.loads(text_data)
-        if data.get(key="message_type") != MessageType.CREATE.value:
+        if data.get("message_type") != MessageType.CREATE.value:
             return
 
-        tournament_name = data.get(key="tournament_name")
+        tournament_name = data.get("tournament_name")
         if tournament_name is None:
             result = ResultType.FAIL.value
         elif tournament_name == NOT_ALLOWED_TOURNAMENT_NAME:

--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -225,6 +225,7 @@ class TournamentGameWaitConsumer(AsyncWebsocketConsumer):
     def __init__(self, *args, **kwargs):
         super().__init__(args, kwargs)
         self.user: Users or None = None
+        self.isProcessingComplete: bool = False
 
     async def connect(self) -> None:
         self.user = self.scope["user"]
@@ -244,6 +245,9 @@ class TournamentGameWaitConsumer(AsyncWebsocketConsumer):
             await self.close()
 
     async def receive(self, text_data: json = None, bytes_data=None) -> None:
+        if self.isProcessingComplete:
+            return
+
         data = json.loads(text_data)
         if data.get("message_type") != MessageType.CREATE.value:
             return
@@ -257,6 +261,7 @@ class TournamentGameWaitConsumer(AsyncWebsocketConsumer):
             result = ResultType.FAIL.value
         else:
             result = ResultType.SUCCESS.value
+            self.isProcessingComplete = True
 
         await self.send(
             json.dumps({"message_type": MessageType.CREATE.value, "result": result})

--- a/back/pong_game/module/GameSetValue.py
+++ b/back/pong_game/module/GameSetValue.py
@@ -10,7 +10,9 @@ BALL_SPEED_X: int = 0
 BALL_SPEED_Z: int = -10
 BALL_RADIUS: int = 20
 MAX_SCORE: int = 5
-PADDLE_BOUNDARY: float = FIELD_WIDTH / 2 - PADDLE_WIDTH / 2
+PADDLE_BOUNDARY: int = FIELD_WIDTH // 2 - PADDLE_WIDTH // 2
+TOURNAMENT_PLAYER_MAX_CNT: int = 4
+NOT_ALLOWED_TOURNAMENT_NAME: str = "wait"
 
 
 class KeyboardInput(Enum):
@@ -30,6 +32,7 @@ class PlayerStatus(Enum):
 
 
 class MessageType(Enum):
+    CREATE = "create"
     READY = "ready"
     START = "start"
     PLAYING = "playing"
@@ -42,3 +45,21 @@ class MessageType(Enum):
 class GameTimeType(Enum):
     START_TIME = "start_time"
     END_TIME = "end_time"
+
+
+class RoundNumber(Enum):
+    ROUND_1 = "1"
+    ROUND_2 = "2"
+    ROUND_3 = "3"
+
+
+class TournamentStatus(Enum):
+    WAIT = "wait"
+    READY = "ready"
+    PLAYING = "playing"
+    END = "end"
+
+
+class ResultType(Enum):
+    SUCCESS = "success"
+    FAIL = "fail"

--- a/back/pong_game/module/Round.py
+++ b/back/pong_game/module/Round.py
@@ -1,0 +1,9 @@
+from .Game import GeneralGame
+from .GameSetValue import RoundNumber
+from .Player import Player
+
+
+class Round(GeneralGame):
+    def __init__(self, player1: Player, player2: Player, round_number: RoundNumber):
+        super().__init__(player1, player2)
+        self.round_number: RoundNumber = round_number

--- a/back/pong_game/module/Tournament.py
+++ b/back/pong_game/module/Tournament.py
@@ -1,0 +1,25 @@
+import json
+
+from .GameSetValue import TournamentStatus
+from .Player import Player
+from .Round import Round
+
+
+class Tournament:
+    def __init__(self, tournament_name: str, create_user_intra_id: str):
+        self.tournament_name: str = tournament_name
+        self.round_list: list[Round or None] = [None, None, None]
+        self.player_list: list[Player or None] = [
+            Player(number=1, intra_id=create_user_intra_id),
+            None,
+            None,
+            None,
+        ]
+        self.player_total_cnt: int = 1
+        self.status: TournamentStatus = TournamentStatus.WAIT
+
+    def build_tournament_wait_dict(self) -> dict:
+        return {
+            "tournament_name": self.tournament_name,
+            "wait_num": str(self.player_total_cnt),
+        }

--- a/back/pong_game/routing.py
+++ b/back/pong_game/routing.py
@@ -8,4 +8,5 @@ websocket_urlpatterns = [
     path("ws/general_game/<uuid:game_id>/", consumers.GeneralGameConsumer.as_asgi()),
     path("ws/login/", consumers.LoginConsumer.as_asgi()),
     path("ws/general_game/wait/", consumers.GeneralGameWaitConsumer.as_asgi()),
+    path("ws/tournament_game/wait/", consumers.TournamentGameWaitConsumer.as_asgi()),
 ]


### PR DESCRIPTION
### Summary
- TournamentGameWaitConsumer 구현했습니다.
- 관련된 테스트를 추가했습니다.
- Round, Tournament 클래스 뼈대를 구현했습니다.
### Describe
#### TournamentGameWaitConsumer 구현했습니다.
- 토너먼트 게임의 첫 시작으로 TournamentGameWaitConsumer를 구현했습니다.
- TournamentGameWaitConsumer는 ＂ws/tournament_game/wait/＂로 접속을 하면 토너먼트 방을 생성하기 전까지 역할을 수행합니다.
- 접속을 하면 
- 1. 현재 있는 토너먼트 리스트를 클라이언트로 보냄
- 2. 클라이언트에서 원하는 토너먼트 이름과 방 생성 버튼을 누르면 토너먼트 이름 유효성을 검사해서 성공, 실패 메시지 클라이언트에게 보냄
- 유효성 검사: 현재 존재하는 토너먼트 이름을 보낼 때, 토너먼트 이름을 안 보낼 때, 금지된 토너먼트 이름을 보낼 때, db에 저장된 토너먼트 이름을 보낼 때
#### 관련된 Round, Tournament 클래스 뼈대를 구현했습니다.
- 간단한 생성자만 구현했습니다.
#### 관련된 테스트를 추가했습니다.
- 1. 현재 존재하는 토너먼트 방을 잘 받아오는지 테스트
- 2. 토너먼트 이름을 consumer에게 보냈을 때 성공 또는 실패를 클라이언트에게 잘 보내는지 테스트를 추가했습니다.

### TODO
- 토너먼트 구현했습니다 서로 연관이 되어 있어서 다른 컨슈머를 구현하면 다른 테스트를 더 추가해야 합니다.
- 실제로 프론트랑 결합해봐야 합니다.