### PR TITLE
[Back-47] update api

### DIFF
--- a/back/accounts/models.py
+++ b/back/accounts/models.py
@@ -47,7 +47,7 @@ class Users(AbstractBaseUser, PermissionsMixin):
     profile_image: str = models.ImageField(
         null=True, blank=True, upload_to="profile_images"
     )
-    house: str = models.CharField(choices=HouseEnum.choices)
+    house: str = models.CharField(choices=HouseEnum.choices, max_length=2)
     win_count: int = models.IntegerField(default=0)
     lose_count: int = models.IntegerField(default=0)
     created_time: datetime = models.DateTimeField(auto_now_add=True, editable=False)

--- a/back/accounts/models.py
+++ b/back/accounts/models.py
@@ -31,6 +31,13 @@ class UserStatusEnum(models.TextChoices):
     OFFLINE = "0", "Offline"
 
 
+class HouseEnum(models.TextChoices):
+    GRYFFINDOR = "GR"
+    RAVENCLAW = "RA"
+    SLYTHERIN = "SL"
+    HUFFLEPUFF = "HU"
+
+
 class Users(AbstractBaseUser, PermissionsMixin):
     user_id: str or uuid = models.UUIDField(
         primary_key=True, default=uuid.uuid4, editable=False
@@ -40,6 +47,7 @@ class Users(AbstractBaseUser, PermissionsMixin):
     profile_image: str = models.ImageField(
         null=True, blank=True, upload_to="profile_images"
     )
+    house: str = models.CharField(choices=HouseEnum.choices)
     win_count: int = models.IntegerField(default=0)
     lose_count: int = models.IntegerField(default=0)
     created_time: datetime = models.DateTimeField(auto_now_add=True, editable=False)

--- a/back/accounts/serializers.py
+++ b/back/accounts/serializers.py
@@ -13,6 +13,7 @@ class UsersSerializer(serializers.ModelSerializer):
             "win_count",
             "lose_count",
             "status",
+            "house",
         )
 
 
@@ -29,4 +30,5 @@ class UsersDetailSerializer(serializers.ModelSerializer):
             "intra_id",
             "created_time",
             "updated_time",
+            "house",
         )

--- a/back/accounts/tests.py
+++ b/back/accounts/tests.py
@@ -80,42 +80,6 @@ class UsersDetailViewSetTest(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_delete_without_authenticate(self):
-        """
-        권한 없이 delete test
-        """
-        url = reverse("users_detail", kwargs={"intra_id": self.user.intra_id})
-        response = self.client.delete(url)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_delete(self):
-        """
-        기본적인 delete test
-        """
-        self.client.force_authenticate(user=self.user)
-        initial_user_count = get_user_model().objects.count()
-        url = reverse("users_detail", kwargs={"intra_id": self.user.intra_id})
-        response = self.client.delete(url)
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        # 삭제 후 유저 수가 1 감소했는지 확인
-        self.assertEqual(get_user_model().objects.count(), initial_user_count - 1)
-        # 삭제된 유저의 pk로 유저가 존재하지 않는지 확인
-        self.assertFalse(get_user_model().objects.filter(pk=self.user.pk).exists())
-
-    def test_delete_other_pk(self):
-        """
-        다른 유저 삭제 가능한지 test
-        """
-        self.client.force_authenticate(user=self.user)
-        initial_user_count = get_user_model().objects.count()
-        url = reverse("users_detail", kwargs={"intra_id": self.other_user.intra_id})
-        response = self.client.delete(url)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        # 삭제 오류 후 유저 수가 동일한지 확인
-        self.assertEqual(get_user_model().objects.count(), initial_user_count)
-        # 삭제된 유저의 pk로 유저가 존재하지 않는지 확인
-        self.assertTrue(get_user_model().objects.filter(pk=self.user.pk).exists())
-
     def test_patch_without_authenticate(self):
         """
         권한 없이 patch test

--- a/back/accounts/urls.py
+++ b/back/accounts/urls.py
@@ -11,9 +11,7 @@ urlpatterns = [
     ),
     path(
         "users/<str:intra_id>/",
-        views.UsersDetailViewSet.as_view(
-            {"get": "list", "patch": "partial_update", "delete": "destroy"}
-        ),
+        views.UsersDetailViewSet.as_view({"get": "list", "patch": "partial_update"}),
         name="users_detail",
     ),
     path("login/", views.Login42APIView.as_view()),

--- a/back/accounts/views.py
+++ b/back/accounts/views.py
@@ -68,11 +68,10 @@ class UsersDetailViewSet(viewsets.ModelViewSet):
     http_method_names = [
         "get",
         "patch",
-        "delete",
-    ]  # TODO delete 나중에 제거 예정
+    ]
     lookup_field: str = "intra_id"
 
-    # 우선 nickname과 profile_image를 제외한 모든 필드를 수정 불가로 설정
+    # nickname과 profile_image, status를 제외한 모든 필드를 수정 불가로 설정
     can_not_change_fields: tuple[str] = (
         "user_id",
         "password",
@@ -83,7 +82,6 @@ class UsersDetailViewSet(viewsets.ModelViewSet):
         "lose_count",
         "created_time",
         "updated_time",
-        "status",
         "is_staff",
         "is_active",
         "groups",
@@ -99,23 +97,6 @@ class UsersDetailViewSet(viewsets.ModelViewSet):
             raise ValidationError({"detail": "존재하지 않는 사용자입니다."})
         serializer = UsersDetailSerializer(queryset, many=True)
         return Response(serializer.data)
-
-    def destroy(self, request, *args, **kwargs) -> Response:
-        """
-        DELETE method override
-        """
-        user = Users.objects.get(intra_id=kwargs["intra_id"])
-        if request.user.intra_id != user.intra_id:
-            raise PermissionDenied(
-                {"detail": "다른 사용자의 정보는 삭제할 수 없습니다."}
-            )
-        if user.profile_image:
-            try:
-                os.remove(os.path.join(settings.MEDIA_ROOT, user.profile_image.name))
-            except FileNotFoundError:
-                print("File not found")
-        self.perform_destroy(user)
-        return Response(status=status.HTTP_204_NO_CONTENT)
 
     def partial_update(self, request, *args, **kwargs) -> Response:
         """

--- a/back/friendrequests/serializers.py
+++ b/back/friendrequests/serializers.py
@@ -1,11 +1,11 @@
 from rest_framework import serializers
-
 from accounts.serializers import UsersSerializer
 from .models import FriendRequests
 
 
 class FriendListSerializer(serializers.ModelSerializer):
-    friend_request: UsersSerializer = UsersSerializer(read_only=True)
+    request_user_id: UsersSerializer = UsersSerializer(read_only=True)
+    response_user_id: UsersSerializer = UsersSerializer(read_only=True)
     request_intra_id: str = serializers.CharField(source="request_user_id.intra_id")
     response_intra_id: str = serializers.CharField(source="response_user_id.intra_id")
 
@@ -16,29 +16,22 @@ class FriendListSerializer(serializers.ModelSerializer):
             "request_intra_id",
             "response_intra_id",
             "status",
-            "friend_request",
+            "request_user_id",
+            "response_user_id",
         )
 
 
 class FriendRequestSerializer(serializers.ModelSerializer):
-    friend_request: UsersSerializer = UsersSerializer(read_only=True)
-
     class Meta:
         model: FriendRequests = FriendRequests
         fields: tuple[str] = (
             "request_id",
             "request_user_id",
             "response_user_id",
-            "friend_request",
         )
 
 
 class FriendRequestDetailSerializer(serializers.ModelSerializer):
-    friend_request: UsersSerializer = UsersSerializer(read_only=True)
-
     class Meta:
         model: FriendRequests = FriendRequests
-        fields: tuple[str] = (
-            "status",
-            "friend_request",
-        )
+        fields: tuple[str] = "__all__"

--- a/back/friendrequests/tests.py
+++ b/back/friendrequests/tests.py
@@ -69,7 +69,8 @@ class FriendListViewSetTestCase(APITestCase):
         """
         self.client.force_authenticate(user=self.user1)
         url = reverse(
-            "friend_list", kwargs={"intra_id": self.user1.intra_id, "status": "accepted"}
+            "friend_list",
+            kwargs={"intra_id": self.user1.intra_id, "status": "accepted"},
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/back/friendrequests/urls.py
+++ b/back/friendrequests/urls.py
@@ -26,5 +26,4 @@ urlpatterns = [
         ),
         name="friend_requests_detail",
     ),
-
 ]

--- a/back/friendrequests/views.py
+++ b/back/friendrequests/views.py
@@ -48,6 +48,9 @@ class FriendListViewSet(viewsets.ModelViewSet):
         else:
             raise ValidationError({"detail": "잘못된 url입니다."})
         serializer = self.serializer_class(queryset, many=True)
+        for d in serializer.data:
+            req_id, res_id = d.pop("request_user_id"), d.pop("response_user_id")
+            d["friend_requests"] = res_id if req_id["intra_id"] == intra_id else req_id
         return Response(serializer.data)
 
 

--- a/back/games/serializers.py
+++ b/back/games/serializers.py
@@ -63,8 +63,8 @@ class GeneralGameLogsSerializer(serializers.ModelSerializer):
 
 
 class GeneralGameLogsListSerializer(serializers.ModelSerializer):
-    player1_user: Users = UsersSerializer(source="player1")
-    player2_user: Users = UsersSerializer(source="player2")
+    player1: Users = UsersSerializer()
+    player2: Users = UsersSerializer()
 
     class Meta:
         model: GeneralGameLogs = GeneralGameLogs
@@ -72,8 +72,8 @@ class GeneralGameLogsListSerializer(serializers.ModelSerializer):
             "game_id",
             "start_time",
             "end_time",
-            "player1_user",
-            "player2_user",
+            "player1",
+            "player2",
             "player1_score",
             "player2_score",
         )
@@ -121,16 +121,16 @@ class TournamentGameLogsSerializer(serializers.ModelSerializer):
 
 
 class TournamentGameLogsListSerializer(serializers.ModelSerializer):
-    player1_user: Users = UsersSerializer(source="player1")
-    player2_user: Users = UsersSerializer(source="player2")
+    player1: Users = UsersSerializer()
+    player2: Users = UsersSerializer()
 
     class Meta:
         model: TournamentGameLogsSerializer = TournamentGameLogs
         fields = (
             "tournament_name",
             "round",
-            "player1_user",
-            "player2_user",
+            "player1",
+            "player2",
             "player1_score",
             "player2_score",
             "start_time",

--- a/back/games/tests.py
+++ b/back/games/tests.py
@@ -142,8 +142,8 @@ class GeneralGameLogsViewSetTest(APITestCase):
         # get 데이터 확인
         self.assertEqual(response.data[0]["start_time"], self.start_time.isoformat())
         self.assertEqual(response.data[0]["end_time"], self.end_time.isoformat())
-        self.assertEqual(response.data[0]["player1_user"]["intra_id"], player1)
-        self.assertEqual(response.data[0]["player2_user"]["intra_id"], player2)
+        self.assertEqual(response.data[0]["player1"]["intra_id"], player1)
+        self.assertEqual(response.data[0]["player2"]["intra_id"], player2)
 
     def test_score_minus(self):
         """
@@ -380,15 +380,9 @@ class TournamentGameLogsViewSetTest(APITestCase):
             reverse("tournament_name_logs", kwargs={"name": self.tournament_name})
         )
         assert len(response.data) == 3
-        self.assertEqual(
-            self.user1.intra_id, response.data[0]["player1_user"]["intra_id"]
-        )
-        self.assertEqual(
-            self.user3.intra_id, response.data[1]["player1_user"]["intra_id"]
-        )
-        self.assertEqual(
-            self.user3.intra_id, response.data[2]["player1_user"]["intra_id"]
-        )
+        self.assertEqual(self.user1.intra_id, response.data[0]["player1"]["intra_id"])
+        self.assertEqual(self.user3.intra_id, response.data[1]["player1"]["intra_id"])
+        self.assertEqual(self.user3.intra_id, response.data[2]["player1"]["intra_id"])
 
         response = self.client.get(
             reverse(

--- a/back/games/views.py
+++ b/back/games/views.py
@@ -1,6 +1,4 @@
 import uuid
-
-import requests
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import IntegrityError, DatabaseError
 from django.db.models import Q
@@ -91,6 +89,7 @@ class GeneralGameLogsListViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
     queryset = GeneralGameLogs.objects.all()
     serializer_class: GeneralGameLogsListSerializer = GeneralGameLogsListSerializer
+    http_method_names = ["get"]
 
     def list(self, request, *args, **kwargs) -> Response:
         if "intra_id" not in kwargs:
@@ -133,6 +132,7 @@ class TournamentGameLogsListViewSet(viewsets.ModelViewSet):
     serializer_class: TournamentGameLogsListSerializer = (
         TournamentGameLogsListSerializer
     )
+    http_method_names = ["get"]
 
     def list(self, request, *args, **kwargs) -> Response:
         if "intra_id" not in kwargs and "name" not in kwargs:

--- a/back/test_user.json
+++ b/back/test_user.json
@@ -18,7 +18,8 @@
       "is_active": true,
       "groups": [],
       "user_permissions": [],
-      "is_test_user": true
+      "is_test_user": true,
+      "house": "GR"
     }
   },
   {
@@ -40,7 +41,8 @@
       "is_active": true,
       "groups": [],
       "user_permissions": [],
-      "is_test_user": true
+      "is_test_user": true,
+      "house": "GR"
     }
   },
   {
@@ -62,7 +64,8 @@
       "is_active": true,
       "groups": [],
       "user_permissions": [],
-      "is_test_user": true
+      "is_test_user": true,
+      "house": "GR"
     }
   },
   {
@@ -84,7 +87,8 @@
       "is_active": true,
       "groups": [],
       "user_permissions": [],
-      "is_test_user": true
+      "is_test_user": true,
+      "house": "GR"
     }
   },
   {
@@ -106,7 +110,8 @@
       "is_active": true,
       "groups": [],
       "user_permissions": [],
-      "is_test_user": true
+      "is_test_user": true,
+      "house": "RA"
     }
   },
   {
@@ -128,7 +133,8 @@
       "is_active": true,
       "groups": [],
       "user_permissions": [],
-      "is_test_user": true
+      "is_test_user": true,
+      "house": "RA"
     }
   },
   {


### PR DESCRIPTION
### Summary

- `Users` 모델의 삭제 기능을 제거했습니다.
- `Users` 모델의 `House` 필드와 그에 맞는 Enum, dict을 추가했습니다.
- `FriendRequest` 모델에서 GET 요청 시, 내가 아닌 상대방의 정보가 `friend_requests` 필드에 들어가도록 변경했습니다.
- `Game` log 들도 GET 요청 시, 모든 정보를 받도록 수정했습니다.
- 그 외에 Black formatter 적용 및 안 쓰는 라이브러리를 제거했습니다.


### Describe

#### `Users` model

- `Users` 의 삭제 기능이 사용되지 않기에 제거헀습니다.
- 코알리숑을 토대로 호그와트 네 개의 기숙사 중 하나로 맵핑하여 `house` 필드에 저장했습니다.

#### `FriendRequest` model

- serializer에서 friend_request가 적용되지 않는 것을 확인했습니다.
- 이에 `request_user_id` 와 `response_user_id` 를 `UserSerializer` 로 필드를 변경해서 `Users` 전체 필드가 보이도록 변경했습니다.
- 그리고 view에서 자신이 아닌 유저의 정보만 남기고 `friend_requests` 필드에 저장되도록 구현했습니다.

#### `Game` 관련 model

- `player1_user` , `player2_user` 가 제대로 적용되지 않는 것을 확인했습니다.
- 위와 마찬가지로 `player1` , `player2` 를 `UserSerializer` 로 필드를 변경해서 `Users` 전체 필드가 보이도록 변경했습니다.

#### Tests

- 모델의 변경에 맞춰서 test를 변경 및 제거했습니다.


### TODO

- 현재 제 로컬에서 아래와 같은 에러가 발생합니다. 수정해야 개발이 원활할 것 같습니다.

```shell
$ django.db.utils.InterfaceError: connection already closed
```

- 모델이 변경되었기 때문에 migration이 local에 남아있다면 지우고 다시 migration 해야 합니다.
- front에게 swagger와 다른 부분을 전달해야 합니다.