### PR TITLE
[Back-48] create user profile image error handler

### DIFF
--- a/back/accounts/views.py
+++ b/back/accounts/views.py
@@ -130,7 +130,10 @@ class UsersDetailViewSet(viewsets.ModelViewSet):
         response = super().partial_update(request, *args, **kwargs)
 
         if previous_image and request.data.get("profile_image") is not None:
-            os.remove(os.path.join(settings.MEDIA_ROOT, previous_image.name))
+            try:
+                os.remove(os.path.join(settings.MEDIA_ROOT, previous_image.name))
+            except FileNotFoundError:
+                pass
         return response
 
 


### PR DESCRIPTION
### Summary

- 프로필 이미지 관련 변경 에러 추가했습니다.


### Describe

- db를 직접 건드려서 파일을 삭제하는 것은 고려하지 않았습니다.
- 프로필 이미지를 db에서 임의로 삭제해도 db에 이미지 주소는 남아있습니다.
- 이것이 나중에 이미지를 변경하면서 이전 이미지를 삭제할 때 에러를 발생시킵니다.
- 그래서 pass로 넘어가도록 만들었습니다.
