### PR TITLE
Back 45 create tournament game consumer

### DIFF
--- a/back/friendrequests/serializers.py
+++ b/back/friendrequests/serializers.py
@@ -34,4 +34,6 @@ class FriendRequestSerializer(serializers.ModelSerializer):
 class FriendRequestDetailSerializer(serializers.ModelSerializer):
     class Meta:
         model: FriendRequests = FriendRequests
-        fields: tuple[str] = "__all__"
+        fields: tuple[str] = (
+            "status",
+        )

--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -290,13 +290,11 @@ class TournamentGameConsumer(AsyncWebsocketConsumer):
     def __init__(self, *args, **kwargs):
         super().__init__(args, kwargs)
         self.user: Users or None = None
-        self.tournament_name: str = self.scope["url_route"]["kwargs"]["tournament_name"]
-        self.group_name_prefix: str = f"tournament_{self.tournament_name}"
-        self.group_name_a: str = self.group_name_prefix + "a"
-        self.group_name_b: str = self.group_name_prefix + "b"
-        self.tournament: Tournament or None = ACTIVE_TOURNAMENTS.get(
-            self.tournament_name
-        )
+        self.tournament_name: str = ""
+        self.group_name_prefix: str = ""
+        self.group_name_a: str = ""
+        self.group_name_b: str = ""
+        self.tournament: Tournament or None = None
 
     async def send_message(self, event) -> None:
         message = event["message"]
@@ -307,9 +305,16 @@ class TournamentGameConsumer(AsyncWebsocketConsumer):
     # TODO accept 위치 테스트 터지면 보기
     async def connect(self) -> None:
         self.user = self.scope["user"]
+        if self.user.is_authenticated:
+            self.tournament_name: str = self.scope["url_route"]["kwargs"][
+                "tournament_name"
+            ]
+            self.group_name_prefix = f"tournament_{self.tournament_name}"
+            self.group_name_a = self.group_name_prefix + "a"
+            self.group_name_b = self.group_name_prefix + "b"
+            self.tournament = ACTIVE_TOURNAMENTS.get(self.tournament_name)
         if (
-            self.user.is_authenticated
-            and self.tournament is not None
+            self.tournament is not None
             and self.tournament.get_statue() == TournamentStatus.WAIT
         ):
             await self.accept()

--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -13,6 +13,9 @@ from .module.GameSetValue import (
     GameTimeType,
     ResultType,
     NOT_ALLOWED_TOURNAMENT_NAME,
+    TournamentStatus,
+    TOURNAMENT_PLAYER_MAX_CNT,
+    TournamentGroupName,
 )
 from .module.GameSetValue import MessageType
 from games.serializers import GeneralGameLogsSerializer
@@ -273,7 +276,105 @@ class TournamentGameWaitConsumer(AsyncWebsocketConsumer):
         else:
             result = ResultType.SUCCESS.value
             self.isProcessingComplete = True
+            # TODO test 필요
+            ACTIVE_TOURNAMENTS[tournament_name] = Tournament(
+                tournament_name=tournament_name, create_user_intra_id=self.user.intra_id
+            )
 
         await self.send(
             json.dumps({"message_type": MessageType.CREATE.value, "result": result})
         )
+
+
+class TournamentGameConsumer(AsyncWebsocketConsumer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(args, kwargs)
+        self.user: Users or None = None
+        self.tournament_name: str = self.scope["url_route"]["kwargs"]["tournament_name"]
+        self.group_name_prefix: str = f"tournament_{self.tournament_name}"
+        self.group_name_a: str = self.group_name_prefix + "a"
+        self.group_name_b: str = self.group_name_prefix + "b"
+        self.tournament: Tournament or None = ACTIVE_TOURNAMENTS.get(
+            self.tournament_name
+        )
+
+    async def send_message(self, event) -> None:
+        message = event["message"]
+
+        # Send message to WebSocket
+        await self.send(text_data=message)
+
+    # TODO accept 위치 테스트 터지면 보기
+    async def connect(self) -> None:
+        self.user = self.scope["user"]
+        if (
+            self.user.is_authenticated
+            and self.tournament is not None
+            and self.tournament.get_statue() == TournamentStatus.WAIT
+        ):
+            await self.accept()
+            player_number, wait_detail_json = (
+                self.tournament.build_tournament_wait_detail_json(
+                    intra_id=self.user.intra_id
+                )
+            )
+            if int(player_number[-1]) <= TOURNAMENT_PLAYER_MAX_CNT // 2:
+                await self.channel_layer.group_add(self.group_name_a, self.channel_name)
+            else:
+                await self.channel_layer.group_add(self.group_name_b, self.channel_name)
+
+            await self.channel_layer.group_send(
+                self.group_name_a,
+                {"type": "send.message", "message": wait_detail_json},
+            )
+            # TODO 테스트 할때 없는 그룹에게 보냈을때 확인 필요
+            await self.channel_layer.group_send(
+                self.group_name_b,
+                {"type": "send.message", "message": wait_detail_json},
+            )
+        else:
+            await self.close()
+
+    async def disconnect(self, close_code) -> None:
+        if not self.user.is_authenticated:
+            return
+
+        if self.tournament.get_statue() == TournamentStatus.READY:
+            return
+
+        self.tournament.disconnect_tournament(self.user.intra_id)
+        if self.tournament.get_player_total_cnt() == 0:
+            ACTIVE_TOURNAMENTS.pop(self.tournament_name)
+
+    async def receive(self, text_data: json = None, bytes_data=None) -> None:
+        data = json.loads(text_data)
+        if data.get("message_type") == MessageType.WAIT.value:
+            number = data.get("number")
+            intra_id = data.get("intra_id")
+            if intra_id != self.user.intra_id:
+                return
+
+            if not self.tournament.try_set_ready(
+                player_number=number, intra_id=intra_id
+            ):
+                return
+
+            if self.tournament.is_all_ready():
+                await self.channel_layer.group_send(
+                    self.group_name_a,
+                    {
+                        "type": "send.message",
+                        "message": self.tournament.build_tournament_ready_json(
+                            TournamentGroupName.A_TEAM
+                        ),
+                    },
+                )
+                await self.channel_layer.group_send(
+                    self.group_name_b,
+                    {
+                        "type": "send.message",
+                        "message": self.tournament.build_tournament_ready_json(
+                            TournamentGroupName.B_TEAM
+                        ),
+                    },
+                )

--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -332,7 +332,6 @@ class TournamentGameConsumer(AsyncWebsocketConsumer):
                 self.group_name_a,
                 {"type": "send.message", "message": wait_detail_json},
             )
-            # TODO 테스트 할때 없는 그룹에게 보냈을때 확인 필요
             await self.channel_layer.group_send(
                 self.group_name_b,
                 {"type": "send.message", "message": wait_detail_json},

--- a/back/pong_game/module/GameSetValue.py
+++ b/back/pong_game/module/GameSetValue.py
@@ -32,6 +32,7 @@ class PlayerStatus(Enum):
 
 
 class MessageType(Enum):
+    WAIT = "wait"
     CREATE = "create"
     READY = "ready"
     START = "start"
@@ -63,3 +64,15 @@ class TournamentStatus(Enum):
 class ResultType(Enum):
     SUCCESS = "success"
     FAIL = "fail"
+
+
+class PlayerNumber(Enum):
+    PLAYER_1 = "player1"
+    PLAYER_2 = "player2"
+    PLAYER_3 = "player3"
+    PLAYER_4 = "player4"
+
+
+class TournamentGroupName(Enum):
+    A_TEAM = "a_team"
+    B_TEAM = "b_team"

--- a/back/pong_game/module/Tournament.py
+++ b/back/pong_game/module/Tournament.py
@@ -95,8 +95,9 @@ class Tournament:
     def get_player_total_cnt(self) -> int:
         return self.player_total_cnt
 
-    def try_set_ready(self, player_number: PlayerNumber, intra_id: str) -> bool:
-        idx = list(PlayerNumber).index(player_number)
+    def try_set_ready(self, player_number: str, intra_id: str) -> bool:
+        player_numbers = [player.value for player in PlayerNumber]
+        idx = player_numbers.index(player_number)
         if (
             self.player_list[idx] is None
             or self.player_list[idx].get_intra_id() != intra_id

--- a/back/pong_game/module/Tournament.py
+++ b/back/pong_game/module/Tournament.py
@@ -76,7 +76,7 @@ class Tournament:
 
     def disconnect_tournament(self, intra_id: str) -> None:
         for idx, player in enumerate(self.player_list):
-            if player.get_intra_id() == intra_id:
+            if player is not None and player.get_intra_id() == intra_id:
                 self.player_list[idx] = None
                 self.player_total_cnt -= 1
 

--- a/back/pong_game/module/Tournament.py
+++ b/back/pong_game/module/Tournament.py
@@ -1,6 +1,14 @@
 import json
 
-from .GameSetValue import TournamentStatus
+from .GameSetValue import (
+    TournamentStatus,
+    MessageType,
+    PlayerNumber,
+    TOURNAMENT_PLAYER_MAX_CNT,
+    PlayerStatus,
+    TournamentGroupName,
+    RoundNumber,
+)
 from .Player import Player
 from .Round import Round
 
@@ -23,3 +31,76 @@ class Tournament:
             "tournament_name": self.tournament_name,
             "wait_num": str(self.player_total_cnt),
         }
+
+    def _join_tournament_with_intra_id(self, intra_id: str) -> PlayerNumber:
+        for idx, player in enumerate(self.player_list):
+            if player.get_intra_id() == intra_id:
+                return PlayerNumber.PLAYER_1
+            elif player is None:
+                self.player_list[idx] = Player(number=idx + 1, intra_id=intra_id)
+                self.player_total_cnt += 1
+                if self.player_total_cnt == TOURNAMENT_PLAYER_MAX_CNT:
+                    self.status = TournamentStatus.READY
+                return list(PlayerNumber)[idx]
+
+    def build_tournament_wait_detail_json(self, intra_id: str) -> tuple[str, json]:
+        player_number = self._join_tournament_with_intra_id(intra_id=intra_id).value
+        return player_number, json.dumps(
+            {
+                "message_type": MessageType.WAIT.value,
+                "intra_id": intra_id,
+                "total": self.player_total_cnt,
+                "number": player_number,
+            }
+        )
+
+    def build_tournament_ready_json(self, team_name: TournamentGroupName) -> json:
+        if team_name == TournamentGroupName.A_TEAM:
+            return json.dumps(
+                {
+                    "message_type": MessageType.READY.value,
+                    "round": RoundNumber.ROUND_1.value,
+                    "1p": self.player_list[0].get_intra_id(),
+                    "2p": self.player_list[1].get_intra_id(),
+                }
+            )
+        else:
+            return json.dumps(
+                {
+                    "message_type": MessageType.READY.value,
+                    "round": RoundNumber.ROUND_2.value,
+                    "1p": self.player_list[2].get_intra_id(),
+                    "2p": self.player_list[3].get_intra_id(),
+                }
+            )
+
+    def disconnect_tournament(self, intra_id: str) -> None:
+        for idx, player in enumerate(self.player_list):
+            if player.get_intra_id() == intra_id:
+                self.player_list[idx] = None
+                self.player_total_cnt -= 1
+
+    def is_all_ready(self) -> bool:
+        for player in self.player_list:
+            if player is None:
+                return False
+            if player.get_status() != PlayerStatus.READY:
+                return False
+
+        return True
+
+    def get_statue(self) -> TournamentStatus:
+        return self.status
+
+    def get_player_total_cnt(self) -> int:
+        return self.player_total_cnt
+
+    def try_set_ready(self, player_number: PlayerNumber, intra_id: str) -> bool:
+        idx = list(PlayerNumber).index(player_number)
+        if (
+            self.player_list[idx] is None
+            or self.player_list[idx].get_intra_id() != intra_id
+        ):
+            return False
+        self.player_list[idx].set_status(PlayerStatus.READY)
+        return True

--- a/back/pong_game/module/Tournament.py
+++ b/back/pong_game/module/Tournament.py
@@ -34,14 +34,14 @@ class Tournament:
 
     def _join_tournament_with_intra_id(self, intra_id: str) -> PlayerNumber:
         for idx, player in enumerate(self.player_list):
-            if player.get_intra_id() == intra_id:
-                return PlayerNumber.PLAYER_1
-            elif player is None:
+            if player is None:
                 self.player_list[idx] = Player(number=idx + 1, intra_id=intra_id)
                 self.player_total_cnt += 1
                 if self.player_total_cnt == TOURNAMENT_PLAYER_MAX_CNT:
                     self.status = TournamentStatus.READY
                 return list(PlayerNumber)[idx]
+            elif player.get_intra_id() == intra_id:
+                return PlayerNumber.PLAYER_1
 
     def build_tournament_wait_detail_json(self, intra_id: str) -> tuple[str, json]:
         player_number = self._join_tournament_with_intra_id(intra_id=intra_id).value

--- a/back/pong_game/routing.py
+++ b/back/pong_game/routing.py
@@ -9,4 +9,8 @@ websocket_urlpatterns = [
     path("ws/login/", consumers.LoginConsumer.as_asgi()),
     path("ws/general_game/wait/", consumers.GeneralGameWaitConsumer.as_asgi()),
     path("ws/tournament_game/wait/", consumers.TournamentGameWaitConsumer.as_asgi()),
+    path(
+        "ws/tournament_game/<str:tournament_name>/",
+        consumers.TournamentGameConsumer.as_asgi(),
+    ),
 ]

--- a/back/pong_game/tests.py
+++ b/back/pong_game/tests.py
@@ -698,7 +698,7 @@ class TournamentGameConsumerTests(TestCase):
 
     @database_sync_to_async
     def get_user(self, intra_id: str):
-        # 데이터베이스에서 사용자 상태 조회
+        # 데이터베이스에서 사용자 조회
         return Users.objects.get(intra_id=intra_id)
 
     def setUp(self):

--- a/back/pong_game/tests.py
+++ b/back/pong_game/tests.py
@@ -663,41 +663,26 @@ class TournamentGameConsumerTests(TestCase):
     TEST_TOURNAMENTS_INFO = [
         {
             "tournament_name": "test_tournament1",
-            "create_user_intra_id": "test_intra_id1",
+            "create_user_intra_id": "room_1_owner",
             "wait_num": "1",
         },
         {
             "tournament_name": "test_tournament2",
-            "create_user_intra_id": "test_intra_id2",
+            "create_user_intra_id": "room_2_owner",
             "wait_num": "1",
         },
     ]
 
     def __init__(self, methodName: str = ...):
         super().__init__(methodName)
-        self.room_1_owner = None
-        self.room_1_user1 = None
-        self.room_1_user2 = None
-        self.room_1_user3 = None
-        self.room_2_owner = None
-        self.room_2_user1 = None
-        self.room_2_user2 = None
-        self.room_2_user3 = None
-
-    @database_sync_to_async
-    def create_test_tournament_log(self, tournament_name: str):
-        # 테스트 사용자 생성
-        TournamentGameLogs.objects.create(
-            tournament_name=tournament_name,
-            round=1,
-            player1=get_user_model().objects.create_user(intra_id="default1"),
-            player2=get_user_model().objects.create_user(intra_id="default2"),
-            player1_score=5,
-            player2_score=0,
-            start_time=timezone.now() - datetime.timedelta(hours=5),
-            end_time=timezone.now(),
-            is_final=False,
-        )
+        self.room_1_owner_id = "room_1_owner"
+        self.room_1_user1_id = "room_1_user1"
+        self.room_1_user2_id = "room_1_user2"
+        self.room_1_user3_id = "room_1_user3"
+        self.room_2_owner_id = "room_2_owner"
+        self.room_2_user1_id = "room_2_user1"
+        self.room_2_user2_id = "room_2_user2"
+        self.room_2_user3_id = "room_2_user3"
 
     @database_sync_to_async
     def create_test_user(self, intra_id):
@@ -809,38 +794,38 @@ class TournamentGameConsumerTests(TestCase):
     async def test_receive_wait_ready_data(self):
         users_info_test_tournament1 = [
             {
-                "intra_id": "test_intra_id1",
+                "intra_id": self.room_1_owner_id,
                 "expected_player_number": PlayerNumber.PLAYER_1,
             },
             {
-                "intra_id": "room_1_user1",
+                "intra_id": self.room_1_user1_id,
                 "expected_player_number": PlayerNumber.PLAYER_2,
             },
             {
-                "intra_id": "room_1_user2",
+                "intra_id": self.room_1_user2_id,
                 "expected_player_number": PlayerNumber.PLAYER_3,
             },
             {
-                "intra_id": "room_1_user3",
+                "intra_id": self.room_1_user3_id,
                 "expected_player_number": PlayerNumber.PLAYER_4,
             },
         ]
 
         users_info_test_tournament2 = [
             {
-                "intra_id": "test_intra_id2",
+                "intra_id": self.room_2_owner_id,
                 "expected_player_number": PlayerNumber.PLAYER_1,
             },
             {
-                "intra_id": "room_2_user1",
+                "intra_id": self.room_2_user1_id,
                 "expected_player_number": PlayerNumber.PLAYER_2,
             },
             {
-                "intra_id": "room_2_user2",
+                "intra_id": self.room_2_user2_id,
                 "expected_player_number": PlayerNumber.PLAYER_3,
             },
             {
-                "intra_id": "room_2_user3",
+                "intra_id": self.room_2_user3_id,
                 "expected_player_number": PlayerNumber.PLAYER_4,
             },
         ]
@@ -860,46 +845,46 @@ class TournamentGameConsumerTests(TestCase):
         users_ready_info_test_tournament1 = [
             {
                 "round": "1",
-                "1p": "test_intra_id1",
-                "2p": "room_1_user1",
+                "1p": self.room_1_owner_id,
+                "2p": self.room_1_user1_id,
             },
             {
                 "round": "1",
-                "1p": "test_intra_id1",
-                "2p": "room_1_user1",
+                "1p": self.room_1_owner_id,
+                "2p": self.room_1_user1_id,
             },
             {
                 "round": "2",
-                "1p": "room_1_user2",
-                "2p": "room_1_user3",
+                "1p": self.room_1_user2_id,
+                "2p": self.room_1_user3_id,
             },
             {
                 "round": "2",
-                "1p": "room_1_user2",
-                "2p": "room_1_user3",
+                "1p": self.room_1_user2_id,
+                "2p": self.room_1_user3_id,
             },
         ]
 
         users_ready_info_test_tournament2 = [
             {
                 "round": "1",
-                "1p": "test_intra_id2",
-                "2p": "room_2_user1",
+                "1p": self.room_2_owner_id,
+                "2p": self.room_2_user1_id,
             },
             {
                 "round": "1",
-                "1p": "test_intra_id2",
-                "2p": "room_2_user1",
+                "1p": self.room_2_owner_id,
+                "2p": self.room_2_user1_id,
             },
             {
                 "round": "2",
-                "1p": "room_2_user2",
-                "2p": "room_2_user3",
+                "1p": self.room_2_user2_id,
+                "2p": self.room_2_user3_id,
             },
             {
                 "round": "2",
-                "1p": "room_2_user2",
-                "2p": "room_2_user3",
+                "1p": self.room_2_user2_id,
+                "2p": self.room_2_user3_id,
             },
         ]
 

--- a/makefile
+++ b/makefile
@@ -8,7 +8,11 @@ down:
 	docker-compose -f ./docker-compose.yml down
 
 test:
-	cd ./back/ && python3 manage.py test --settings=back.test_settings
+	cd ./back/ && python3 manage.py test  --settings=back.test_settings
+#	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameConsumerTests.test_disconnect_test2 --settings=back.test_settings
+#	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameConsumerTests.test_overflow_user_connection_test --settings=back.test_settings
+
+
 
 re: down
 	docker-compose -f ./docker-compose.yml up --build --detach


### PR DESCRIPTION
### Summary
- Friend_Requests patch 쪽 serializer 필드 변경했습니다.
- TournamentGameConsumer를 생성했습니다.
- 관련된 테스트를 만들었습니다.
### Describe
#### Friend_Requests patch 쪽 serializer 필드 변경했습니다.
- status만 변경 가능하게 수정했습니다.
#### TournamentGameConsumer를 생성했습니다.
- tournament_game_socket.md의 5번부터 8번까지의 내용을 구현했습니다.
- 짝 코딩을 통해 구현했습니다.
- 짝 코딩 이후 바뀐 내용은
- 1. disconnect_tournament 함수에서 player가 None일 때 에러처리 추가
- 2. init scope 에러가 떠서 위치를 변경
- 3. player_number가 str로 들어와서 수정
- 입니다. 각각 커밋을 참고 해주시기 바랍니다.
#### 관련된 테스트를 만들었습니다.
- test_receive_wait_ready_data
  - 8명의 유저를 만들고 4명씩 각각 방을 만들어서 정상적으로 레디 메시지를 받는지 확인하는 테스트입니다.
- test_disconnect_test1
  - 방 인원이 3명이고 정상적으로 전부 다 나갔을 때 방이 사라지는지 확인하는 테스트입니다.
- test_disconnect_test2
  - 방 인원이 2명이고 한 명이 나갔다가 다시 들어왔을 때 방이 안 사라지는지, 빈자리 그대로 들어오는지 확인하는 테스트입니다.
- test_overflow_user_connection_test
  - 4명이 들어와서 꽉 찬 방에 유저가 접속 요청 했을 때 거부되는지 확인하는 테스트입니다.
### TODO
- 비동기 테스트에 문제가 있습니다.
- 이전까지는 make test로 한번에 테스트할 수 있었지만
- 이번에 테스트를 추가하면서 비동기적으로 테스트를 하다 보니 문제가 발생했습니다.
  - 1. 대기 방을 불러오는 테스트랑 다 나가면 대기 방을 삭제하는 테스트가 비동기로 수행하다 보니 대기 방을 삭제 후 대기 방 불러오는 테스트에서 실패됩니다.
  - 2. RuntimeError: asyncio.locks.Lock object at <...> is bound to a different event loop 이런 에러가 생깁니다.
- 이것을 수정하기 위해서는 pytest로 리팩토링 하는 과정이 필요해 보입니다.
- 일단 우선순위가 consumer 구현이 높아서 test 관련 에러는 나중에 처리하기로 했습니다.
- 그전까지는 make file에 pong_game.tests.TournamentGameConsumerTests.test_disconnect_test2 처럼 개별적으로 테스트해야 할 것 같습니다.