### PR TITLE
[Back-51] satisfy front requirements

### DIFF
--- a/back/accounts/views.py
+++ b/back/accounts/views.py
@@ -140,9 +140,7 @@ class UsersDetailViewSet(viewsets.ModelViewSet):
 class Login42APIView(APIView):
     def get(self, request, *args, **kwargs) -> redirect:
         if request.user.is_authenticated:
-            return redirect(
-                f"http://127.0.0.1:8000/api/v1/users/{request.user.intra_id}/"
-            )
+            return redirect("https://127.0.0.1/")
 
         client_id = os.environ.get("CLIENT_ID")
         response_type = "code"
@@ -158,9 +156,7 @@ class Login42APIView(APIView):
 class CallbackAPIView(APIView):
     def get(self, request, *args, **kwargs) -> redirect:
         if request.user.is_authenticated:
-            return redirect(
-                f"http://127.0.0.1:8000/api/v1/users/{request.user.intra_id}/"
-            )
+            return redirect("https://127.0.0.1/")
 
         if request.session.get("state") and not request.GET.get(
             "state"
@@ -173,6 +169,10 @@ class CallbackAPIView(APIView):
             "https://api.intra.42.fr/v2/me",
             headers={"Authorization": f"Bearer {access_token}"},
         )
+        # 42 api에 정보 요청 실패
+        if user_info_request.status_code != 200:
+            return redirect("https://127.0.0.1/")
+
         user_info = user_info_request.json()
         coalition_info_request = requests.get(
             f"https://api.intra.42.fr/v2/users/{user_info['id']}/coalitions",
@@ -197,7 +197,7 @@ class CallbackAPIView(APIView):
             user_instance.save()
         # login
         login(request, user_instance)
-        return redirect(f"http://127.0.0.1:8000/api/v1/users/{user_instance.intra_id}/")
+        return redirect("https://127.0.0.1/")
 
     def _get_access_token(self, request) -> str:
         grant_type = "authorization_code"
@@ -221,7 +221,7 @@ class CallbackAPIView(APIView):
 
 def logout_view(request) -> redirect:
     logout(request)
-    return redirect("/")
+    return redirect("https://127.0.0.1/")
 
 
 # TODO test 용도 삭제 해야함
@@ -239,8 +239,9 @@ class TestAccountLogin(APIView):
             user_instance = Users.objects.get(intra_id=kwargs["intra_id"])
             if user_instance.is_test_user:
                 login(request, user_instance)
-                return Response({"message": "로그인 성공."}, status=200)
             else:
-                return Response({"error": "허용되지 않는 유저입니다."}, status=403)
+                print("Error: 허용 되지 않은 유저입니다.")
+            return redirect("https://127.0.0.1/")
         except Users.DoesNotExist:
-            return Response({"error": "사용자를 찾을 수 없습니다."}, status=404)
+            print("Error: 사용자를 찾을 수 없습니다.")
+            return redirect("https://127.0.0.1/")

--- a/back/back/urls.py
+++ b/back/back/urls.py
@@ -23,17 +23,17 @@ urlpatterns = [
     path("api/v1/", include("accounts.urls")),
     path("api/v1/", include("friendrequests.urls")),
     re_path(
-        r"^swagger(?P<format>\.json|\.yaml)$",
+        r"^api/v1/swagger(?P<format>\.json|\.yaml)$",
         schema_view_v1.without_ui(cache_timeout=0),
         name="schema-json",
     ),
     re_path(
-        r"^swagger/$",
+        r"^api/v1/swagger/$",
         schema_view_v1.with_ui("swagger", cache_timeout=0),
         name="schema-swagger-ui",
     ),
     re_path(
-        r"^redoc/$",
+        r"^api/v1/redoc/$",
         schema_view_v1.with_ui("redoc", cache_timeout=0),
         name="schema-redoc",
     ),


### PR DESCRIPTION
### Summary

- login, logout 시 redirect 주소를 모두 `https://127.0.0.1/` 로 변경했습니다.
- swagger 앞에 `api/v1/` 를 추가했습니다.


### Describe

- login, logout 시 redirect 주소를 모두 `https://127.0.0.1/` 로 변경했습니다.
- 42인증이 안 될 시도 같은 주소로 리다이렉트 했습니다.
- swagger 앞에 `api/v1/` 를 추가했습니다.
- media는 이미 `api/v1/` 가 추가되어 있어서 따로 변경하지 않았습니다.
