### PR TITLE
[Back-50] create tournament game round consumer test

### DIFF
--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -353,7 +353,21 @@ class TournamentGameConsumer(AsyncWebsocketConsumer):
         if self.tournament.get_status() == TournamentStatus.READY:
             return
 
-        self.tournament.disconnect_tournament(self.user.intra_id)
+        # 나간 인원과 줄어든 현재 인원을 전송
+        await self.channel_layer.group_send(
+            self.group_name_a,
+            {
+                "type": "send.message",
+                "message": self.tournament.disconnect_tournament(self.user.intra_id),
+            },
+        )
+        await self.channel_layer.group_send(
+            self.group_name_b,
+            {
+                "type": "send.message",
+                "message": self.tournament.disconnect_tournament(self.user.intra_id),
+            },
+        )
         if self.tournament.get_player_total_cnt() == 0:
             ACTIVE_TOURNAMENTS.pop(self.tournament_name)
 

--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -429,9 +429,19 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
             self.round = self.tournament.get_round(self.round_number)
             self.game_group_name = self.tournament_name + "_" + str(self.round_number)
             self.tournament_broadcast = self.tournament_name + "_broadcast"
+            # TODO if 문 간소화 by myko
             if (
                 self.tournament is not None
-                and self.tournament.get_status() == TournamentStatus.READY
+                and (
+                    (
+                        self.tournament.get_status() == TournamentStatus.READY
+                        and self.round_number < 3
+                    )
+                    or (
+                        self.tournament.get_status() == TournamentStatus.PLAYING
+                        and self.round_number == 3
+                    )
+                )
                 and self.round is not None
                 and self.round.get_player(self.user.intra_id) is not None
             ):
@@ -467,11 +477,12 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
                 and self.tournament_name in ACTIVE_TOURNAMENTS.keys()
             ):
                 ACTIVE_TOURNAMENTS.pop(self.tournament_name)
-            self.game_loop_task.cancel()
-            try:  # cancel() 동작이 끝날 때까지 대기
-                await self.game_loop_task
-            except asyncio.CancelledError:
-                pass  # task가 이미 취소된 경우
+            if self.game_loop_task is not None:
+                self.game_loop_task.cancel()
+                try:  # cancel() 동작이 끝날 때까지 대기
+                    await self.game_loop_task
+                except asyncio.CancelledError:
+                    pass  # task가 이미 취소된 경우
         await self.channel_layer.group_discard(
             self.tournament_broadcast, self.channel_name
         )
@@ -483,11 +494,17 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
     async def receive(self, text_data: json = None, bytes_data=None) -> None:
         data = json.loads(text_data)
         message_type = data.get("message_type")
+        # TODO if문 간소화 하기
         if (
             message_type == MessageType.READY.value
             and self.tournament.get_status() == TournamentStatus.READY
+            and self.round_number < 3
+        ) or (
+            message_type == MessageType.READY.value
+            and self.tournament.get_status() == TournamentStatus.PLAYING
+            and self.round_number == 3
         ):
-            self.round.set_ready(self.user.intra_id)
+            self.round.set_round_ready(self.user.intra_id)
             if self.round.is_all_ready():
                 await self.channel_layer.group_send(
                     self.game_group_name,
@@ -545,33 +562,39 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
         if self.round_number == 3:
             self.tournament.set_status(TournamentStatus.END)
             try:
-                self.save_game_data_to_db()
+                await self.save_game_data_to_db()
                 await self.channel_layer.group_send(
                     self.tournament_broadcast,
-                    json.dumps(
+                    (
                         {
-                            "message_type": MessageType.COMPLETE.value,
+                            "type": "game.message",
+                            "message": json.dumps(
+                                {"message_type": MessageType.COMPLETE.value}
+                            ),
                         }
                     ),
                 )
             except ValidationError:
                 await self.channel_layer.group_send(
                     self.tournament_broadcast,
-                    json.dumps(
+                    (
                         {
-                            "message_type": MessageType.ERROR.value,
+                            "type": "game.message",
+                            "message": json.dumps(
+                                {"message_type": MessageType.ERROR.value}
+                            ),
                         }
                     ),
                 )
         else:
             round1, round2 = self.tournament.get_round(1), self.tournament.get_round(2)
             self.winner_group = self.tournament_name + "_winner"
-            self.channel_layer.group_add(self.winner_group, self.channel_name)
+            await self.channel_layer.group_add(self.winner_group, self.channel_name)
             if (
                 round1.get_status() == PlayerStatus.END
                 and round2.get_status() == PlayerStatus.END
             ):
-                self.channel_layer.group_send(
+                await self.channel_layer.group_send(
                     self.winner_group,
                     {
                         "type": "game.message",
@@ -586,7 +609,7 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
     @database_sync_to_async
     def save_game_data_to_db(self) -> None:
         for i in range(1, 4):
-            round_i = self.tournament.get_round(i)
-            serializer = TournamentGameLogsSerializer(data=round_i.get_db_data())
+            data = self.tournament.get_db_datas(i)
+            serializer = TournamentGameLogsSerializer(data=data)
             if serializer.is_valid(raise_exception=True):
                 serializer.save()

--- a/back/pong_game/module/GameSetValue.py
+++ b/back/pong_game/module/GameSetValue.py
@@ -26,6 +26,7 @@ class KeyboardInput(Enum):
 class PlayerStatus(Enum):
     WAIT = "wait"
     READY = "ready"
+    ROUND_READY = "round_ready"
     PLAYING = "playing"
     SCORE = "score"
     END = "end"

--- a/back/pong_game/module/Paddle.py
+++ b/back/pong_game/module/Paddle.py
@@ -1,7 +1,5 @@
 from .GameSetValue import (
     PADDLE_SPEED,
-    FIELD_WIDTH,
-    PADDLE_WIDTH,
     FIELD_LENGTH,
     KeyboardInput,
     PADDLE_BOUNDARY,
@@ -10,10 +8,12 @@ from .GameSetValue import (
 
 class Paddle:
     def __init__(self, number: int):
+        self.number: int = number
         self.position_x: float = 0
         self.position_y: float = 0
-        self.position_z: float = FIELD_LENGTH / 2 if number == 1 else -FIELD_LENGTH / 2
-
+        self.position_z: float = (
+            FIELD_LENGTH / 2 if self.number == 1 else -FIELD_LENGTH / 2
+        )
         self.left: bool = False
         self.right: bool = False
 
@@ -41,6 +41,14 @@ class Paddle:
                 self._move(1)
             elif not self.left and self.right:
                 self._move(-1)
+
+    def reset_position(self, number: int) -> None:
+        self.number = number
+        self.position_x = 0
+        self.position_y = 0
+        self.position_z = FIELD_LENGTH / 2 if self.number == 1 else -FIELD_LENGTH / 2
+        self.left = False
+        self.right = False
 
     def _move(self, direction: int) -> None:
         new_paddle_x = self.position_x + direction * PADDLE_SPEED

--- a/back/pong_game/module/Player.py
+++ b/back/pong_game/module/Player.py
@@ -24,5 +24,9 @@ class Player:
     def set_status(self, status: PlayerStatus) -> None:
         self.status = status
 
+    def set_number(self, number: int) -> None:
+        self.number = number
+        self.paddle.reset_position(number)
+
     def paddle_handler(self, key_input: str) -> None:
         self.paddle.input_handler(key_input)

--- a/back/pong_game/module/Round.py
+++ b/back/pong_game/module/Round.py
@@ -61,17 +61,28 @@ class Round(GeneralGame):
             }
         )
 
+    def is_all_ready(self) -> bool:
+        if self.player1 is None or self.player2 is None:
+            return False
+        if (
+            self.player1.get_status()
+            == self.player2.get_status()
+            == PlayerStatus.ROUND_READY
+        ):
+            return True
+        return False
+
     def get_winner(self) -> str:
         return self.winner
 
     def get_is_closed(self) -> bool:
         return self.is_closed
 
-    def set_ready(self, intra_id: str) -> None:
+    def set_round_ready(self, intra_id: str) -> None:
         if intra_id == self.player1.get_intra_id():
-            self.player1.set_status(PlayerStatus.READY)
+            self.player1.set_status(PlayerStatus.ROUND_READY)
         elif intra_id == self.player2.get_intra_id():
-            self.player2.set_status(PlayerStatus.READY)
+            self.player2.set_status(PlayerStatus.ROUND_READY)
 
     def set_is_closed(self, is_closed: bool) -> None:
         self.is_closed = is_closed

--- a/back/pong_game/module/Round.py
+++ b/back/pong_game/module/Round.py
@@ -14,10 +14,12 @@ class Round(GeneralGame):
         self.is_closed: bool = False
 
     def build_start_json(self) -> json:
-        return {
-            "message_type": MessageType.START.value,
-            "round": self.round_number.value,
-        }
+        return json.dumps(
+            {
+                "message_type": MessageType.START.value,
+                "round": self.round_number.value,
+            }
+        )
 
     def build_end_json(self) -> json:
         self.winner = (
@@ -30,12 +32,14 @@ class Round(GeneralGame):
             if self.score1 > self.score2
             else self.player1.get_intra_id()
         )
-        return {
-            "message_type": MessageType.END.value,
-            "round": self.round_number.value,
-            "winner": self.winner,
-            "loser": self.loser,
-        }
+        return json.dumps(
+            {
+                "message_type": MessageType.END.value,
+                "round": self.round_number.value,
+                "winner": self.winner,
+                "loser": self.loser,
+            }
+        )
 
     def build_stay_json(self) -> json:
         self.winner = (
@@ -48,12 +52,14 @@ class Round(GeneralGame):
             if self.score1 > self.score2
             else self.player1.get_intra_id()
         )
-        return {
-            "message_type": MessageType.STAY.value,
-            "round": self.round_number.value,
-            "winner": self.winner,
-            "loser": self.loser,
-        }
+        return json.dumps(
+            {
+                "message_type": MessageType.STAY.value,
+                "round": self.round_number.value,
+                "winner": self.winner,
+                "loser": self.loser,
+            }
+        )
 
     def get_winner(self) -> str:
         return self.winner

--- a/back/pong_game/module/Tournament.py
+++ b/back/pong_game/module/Tournament.py
@@ -107,11 +107,16 @@ class Tournament:
                 }
             )
 
-    def disconnect_tournament(self, intra_id: str) -> None:
+    def disconnect_tournament(self, intra_id: str) -> json:
+        data = {"message_type": MessageType.WAIT.value}
         for idx, player in enumerate(self.player_list):
             if player is not None and player.get_intra_id() == intra_id:
                 self.player_list[idx] = None
                 self.player_total_cnt -= 1
+                data["intra_id"] = intra_id
+                data["total"] = self.player_total_cnt
+                data["number"] = list(PlayerNumber)[idx].value
+        return json.dumps(data)
 
     def is_all_ready(self) -> bool:
         for player in self.player_list:

--- a/back/pong_game/module/Tournament.py
+++ b/back/pong_game/module/Tournament.py
@@ -35,7 +35,9 @@ class Tournament:
     def _join_tournament_with_intra_id(self, intra_id: str) -> PlayerNumber:
         for idx, player in enumerate(self.player_list):
             if player is None:
-                self.player_list[idx] = Player(number=idx + 1, intra_id=intra_id)
+                self.player_list[idx] = Player(
+                    number=2 if idx % 2 else 1, intra_id=intra_id
+                )
                 self.player_total_cnt += 1
                 if self.player_total_cnt == TOURNAMENT_PLAYER_MAX_CNT:
                     self.status = TournamentStatus.READY
@@ -93,6 +95,8 @@ class Tournament:
                     player2 = player
             player1.set_status(PlayerStatus.READY)
             player2.set_status(PlayerStatus.READY)
+            player1.set_number(1)
+            player2.set_number(2)
             self.round_list[2] = Round(player1, player2, RoundNumber.ROUND_3)
             return json.dumps(
                 {

--- a/back/pong_game/routing.py
+++ b/back/pong_game/routing.py
@@ -14,7 +14,7 @@ websocket_urlpatterns = [
         consumers.TournamentGameConsumer.as_asgi(),
     ),
     path(
-        "ws/tournament_game/<str:tournament_name>/<int:round>",
+        "ws/tournament_game/<str:tournament_name>/<int:round>/",
         consumers.TournamentGameRoundConsumer.as_asgi(),
     ),
 ]

--- a/back/pong_game/routing.py
+++ b/back/pong_game/routing.py
@@ -13,4 +13,8 @@ websocket_urlpatterns = [
         "ws/tournament_game/<str:tournament_name>/",
         consumers.TournamentGameConsumer.as_asgi(),
     ),
+    path(
+        "ws/tournament_game/<str:tournament_name>/<int:round>",
+        consumers.TournamentGameRoundConsumer.as_asgi(),
+    ),
 ]

--- a/back/pong_game/tests.py
+++ b/back/pong_game/tests.py
@@ -1174,7 +1174,6 @@ class TournamentGameRoundConsumerTests(TestCase):
         for idx, communicator in enumerate(communicators):
             while await communicator.receive_nothing() is False:
                 message = await communicator.receive_from()
-                print(f"idx={idx}, discard={message}")
 
     async def perform_test_sequence(
         self, tournament_name: str, users_info: list[dict]
@@ -1339,12 +1338,9 @@ class TournamentGameRoundConsumerTests(TestCase):
             )
         )
 
-        print("\n\n=============Round 1=============\n")
-
         while True:
             user1_response = await self.test_tournament1_communicators[0].receive_from()
             user1_dict = json.loads(user1_response)
-            print(user1_dict)
             if (
                 user1_dict["message_type"] == "end"
                 or user1_dict["message_type"] == "stay"
@@ -1354,19 +1350,15 @@ class TournamentGameRoundConsumerTests(TestCase):
         while True:
             user2_response = await self.test_tournament1_communicators[1].receive_from()
             user2_dict = json.loads(user2_response)
-            print(user2_dict)
             if (
                 user2_dict["message_type"] == "end"
                 or user2_dict["message_type"] == "stay"
             ):
                 break
 
-        print("\n\n=============Round 2=============\n")
-
         while True:
             user3_response = await self.test_tournament1_communicators[2].receive_from()
             user3_dict = json.loads(user3_response)
-            print(user3_dict)
             if (
                 user3_dict["message_type"] == "end"
                 or user3_dict["message_type"] == "stay"
@@ -1376,7 +1368,6 @@ class TournamentGameRoundConsumerTests(TestCase):
         while True:
             user4_response = await self.test_tournament1_communicators[3].receive_from()
             user4_dict = json.loads(user4_response)
-            print(user4_dict)
             if (
                 user4_dict["message_type"] == "end"
                 or user4_dict["message_type"] == "stay"
@@ -1407,14 +1398,13 @@ class TournamentGameRoundConsumerTests(TestCase):
             )
         )
 
-        # await self.discard_all_message(self.test_tournament1_communicators)
+        await self.discard_all_message(self.test_tournament1_communicators)
 
         # 연결 끊기
         for communicator in self.test_tournament1_communicators:
             await communicator.disconnect()
 
         self.test_tournament1_communicators = []
-
         self.test_tournament1_communicators.append(
             await self.connect_and_send_ready_data(
                 tournament_name=self.room_1_name,
@@ -1443,18 +1433,18 @@ class TournamentGameRoundConsumerTests(TestCase):
             )
         )
 
-        print("\n\n=============Round 3=============\n")
+        await self.test_tournament1_communicators[0].receive_from()
+        await self.test_tournament1_communicators[1].receive_from()
 
-        await self.test_tournament1_communicators[1].send_to(
+        await self.test_tournament1_communicators[0].send_to(
             text_data=json.dumps(
                 {"message_type": "playing", "number": "player1", "input": "left_press"}
             )
         )
 
         while True:
-            user2_response = await self.test_tournament1_communicators[1].receive_from()
+            user2_response = await self.test_tournament1_communicators[0].receive_from()
             user2_dict = json.loads(user2_response)
-            print(user2_dict)
             if (
                 user2_dict["message_type"] == "end"
                 or user2_dict["message_type"] == "stay"
@@ -1462,9 +1452,8 @@ class TournamentGameRoundConsumerTests(TestCase):
                 break
 
         while True:
-            user4_response = await self.test_tournament1_communicators[3].receive_from()
+            user4_response = await self.test_tournament1_communicators[1].receive_from()
             user4_dict = json.loads(user4_response)
-            print(user4_dict)
             if (
                 user4_dict["message_type"] == "end"
                 or user4_dict["message_type"] == "stay"
@@ -1483,18 +1472,7 @@ class TournamentGameRoundConsumerTests(TestCase):
             )
         )
 
-        print("\n\n=============Save DB=============\n")
-
-        a = await self.wait_for_tournament_data(
-            tournamnet_name=self.room_1_name, round=1
-        )
-        print(a.__dict__)
-        a = await self.wait_for_tournament_data(
-            tournamnet_name=self.room_1_name, round=2
-        )
-        print(a.__dict__)
-        a = await self.wait_for_tournament_data(
-            tournamnet_name=self.room_1_name, round=3
-        )
-        print(a.__dict__)
+        await self.wait_for_tournament_data(tournamnet_name=self.room_1_name, round=1)
+        await self.wait_for_tournament_data(tournamnet_name=self.room_1_name, round=2)
+        await self.wait_for_tournament_data(tournamnet_name=self.room_1_name, round=3)
         await self.discard_all_message(self.test_tournament1_communicators)

--- a/back/pong_game/tests.py
+++ b/back/pong_game/tests.py
@@ -1339,6 +1339,8 @@ class TournamentGameRoundConsumerTests(TestCase):
             )
         )
 
+        print("\n\n=============Round 1=============\n")
+
         while True:
             user1_response = await self.test_tournament1_communicators[0].receive_from()
             user1_dict = json.loads(user1_response)
@@ -1358,6 +1360,8 @@ class TournamentGameRoundConsumerTests(TestCase):
                 or user2_dict["message_type"] == "stay"
             ):
                 break
+
+        print("\n\n=============Round 2=============\n")
 
         while True:
             user3_response = await self.test_tournament1_communicators[2].receive_from()
@@ -1439,6 +1443,34 @@ class TournamentGameRoundConsumerTests(TestCase):
             )
         )
 
+        print("\n\n=============Round 3=============\n")
+
+        await self.test_tournament1_communicators[1].send_to(
+            text_data=json.dumps(
+                {"message_type": "playing", "number": "player1", "input": "left_press"}
+            )
+        )
+
+        while True:
+            user2_response = await self.test_tournament1_communicators[1].receive_from()
+            user2_dict = json.loads(user2_response)
+            print(user2_dict)
+            if (
+                user2_dict["message_type"] == "end"
+                or user2_dict["message_type"] == "stay"
+            ):
+                break
+
+        while True:
+            user4_response = await self.test_tournament1_communicators[3].receive_from()
+            user4_dict = json.loads(user4_response)
+            print(user4_dict)
+            if (
+                user4_dict["message_type"] == "end"
+                or user4_dict["message_type"] == "stay"
+            ):
+                break
+
         await self.discard_all_message(self.test_tournament1_communicators)
         await self.test_tournament1_communicators[0].send_to(
             json.dumps(
@@ -1450,6 +1482,8 @@ class TournamentGameRoundConsumerTests(TestCase):
                 }
             )
         )
+
+        print("\n\n=============Save DB=============\n")
 
         a = await self.wait_for_tournament_data(
             tournamnet_name=self.room_1_name, round=1

--- a/back/pong_game/tests.py
+++ b/back/pong_game/tests.py
@@ -329,6 +329,7 @@ class GeneralGameConsumerTests(TestCase):
         while True:
             user1_response = await communicator1.receive_from()
             user1_dict = json.loads(user1_response)
+            print(user1_dict)
             if user1_dict["message_type"] == "end":
                 break
 
@@ -1048,3 +1049,418 @@ class TournamentGameConsumerTests(TestCase):
         self.assertEqual(tournament.status, TournamentStatus.READY)
         # 거부 하는지 확인
         self.assertFalse(connected)
+
+
+class TournamentGameRoundConsumerTests(TestCase):
+    expected_tournaments_data: list[dict[str, str]]
+    TEST_TOURNAMENTS_INFO = [
+        {
+            "tournament_name": "test_tournament1",
+            "create_user_intra_id": "room_1_owner",
+            "wait_num": "1",
+        },
+        {
+            "tournament_name": "test_tournament2",
+            "create_user_intra_id": "room_2_owner",
+            "wait_num": "1",
+        },
+    ]
+
+    def __init__(self, methodName: str = ...):
+        super().__init__(methodName)
+        self.room_1_name = "test_tournament1"
+        self.room_2_name = "test_tournament2"
+        self.room_1_owner_id = "room_1_owner"
+        self.room_1_user1_id = "room_1_user1"
+        self.room_1_user2_id = "room_1_user2"
+        self.room_1_user3_id = "room_1_user3"
+        self.room_2_owner_id = "room_2_owner"
+        self.room_2_user1_id = "room_2_user1"
+        self.room_2_user2_id = "room_2_user2"
+        self.room_2_user3_id = "room_2_user3"
+
+    @database_sync_to_async
+    def create_test_user(self, intra_id):
+        # 테스트 사용자 생성
+        return get_user_model().objects.create_user(intra_id=intra_id)
+
+    @database_sync_to_async
+    def delete_test_user(self, user):
+        # 테스트 사용자 삭제
+        user.delete()
+
+    @database_sync_to_async
+    def get_user(self, intra_id: str):
+        # 데이터베이스에서 사용자 조회
+        return Users.objects.get(intra_id=intra_id)
+
+    @database_sync_to_async
+    def get_tournament_data(self, tournamnet_name: str, round: int):
+        try:
+            return TournamentGameLogs.objects.get(
+                tournament_name=tournamnet_name, round=round
+            )
+        except GeneralGameLogs.DoesNotExist:
+            return None
+
+    async def wait_for_tournament_data(
+        self, tournamnet_name: str, round: int, timeout=1
+    ):
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            try:
+                game_data = await self.get_tournament_data(
+                    tournamnet_name=tournamnet_name, round=round
+                )
+                if game_data:
+                    return game_data
+            except TournamentGameLogs.DoesNotExist:
+                await asyncio.sleep(0.2)
+        return None
+
+    def setUp(self):
+        """
+        가짜 토너먼트 데이터 준비
+        """
+        self.fake_tournaments = {
+            tournament_info["tournament_name"]: Tournament(
+                tournament_name=tournament_info["tournament_name"],
+                create_user_intra_id=tournament_info["create_user_intra_id"],
+            )
+            for tournament_info in self.TEST_TOURNAMENTS_INFO
+        }
+        # 가짜 데이터를 ACTIVE_TOURNAMENTS에 주입
+        ACTIVE_TOURNAMENTS.update(self.fake_tournaments)
+
+        self.expected_tournaments_data = [
+            {
+                "tournament_name": tournament_info["tournament_name"],
+                "wait_num": tournament_info["wait_num"],
+            }
+            for tournament_info in self.TEST_TOURNAMENTS_INFO
+        ]
+
+    async def connect_and_echo_data(self, tournament_name: str, user: Users) -> tuple:
+        """
+        연결하고 받은 메시지를 그대로 다시 보내는 함수
+        """
+        communicator = WebsocketCommunicator(
+            application, f"/ws/tournament_game/{tournament_name}/"
+        )
+        communicator.scope["user"] = user
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+        response = await communicator.receive_from()
+        await communicator.send_to(response)
+        response_dict = json.loads(response)
+        return communicator, response_dict
+
+    async def connect_and_send_ready_data(
+        self, tournament_name: str, user: Users, round: int, ready_data: dict
+    ) -> WebsocketCommunicator:
+        """
+        연결하고 ready_data를 send_to함
+        """
+        communicator = WebsocketCommunicator(
+            application, f"/ws/tournament_game/{tournament_name}/{round}/"
+        )
+        communicator.scope["user"] = user
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+        await communicator.send_to(json.dumps(ready_data))
+        return communicator
+
+    async def discard_all_message(self, communicators: list):
+        for idx, communicator in enumerate(communicators):
+            while await communicator.receive_nothing() is False:
+                message = await communicator.receive_from()
+                print(f"idx={idx}, discard={message}")
+
+    async def perform_test_sequence(
+        self, tournament_name: str, users_info: list[dict]
+    ) -> list:
+        """
+        특정 토너먼트에 대해 사용자 생성, 연결 및 대기 메시지 확인을 수행하는 메서드.
+        communicators를 반환
+        """
+        communicators = []
+        total_num = 1
+        for user_info in users_info:
+            user = await self.create_test_user(intra_id=user_info["intra_id"])
+            communicator, response_dict = await self.connect_and_echo_data(
+                tournament_name=tournament_name, user=user
+            )
+
+            self.assertEqual(response_dict["message_type"], MessageType.WAIT.value)
+            self.assertEqual(response_dict["intra_id"], user.intra_id)
+            self.assertEqual(response_dict["total"], total_num)
+            self.assertEqual(
+                response_dict["number"], user_info["expected_player_number"].value
+            )
+
+            communicators.append(communicator)
+            total_num += 1
+        return communicators
+
+    async def check_recieved_ready_messgae_valid(
+        self, users_ready_info: list[dict], communicators: list
+    ) -> None:
+        """
+        ready_message가 있는지, 그 값이 올바른지 확인
+        """
+        info_index: int = 0
+        has_ready_message: bool = False
+        for communicator in communicators:
+            while await communicator.receive_nothing() is False:
+                message = await communicator.receive_from()
+                message_dict = json.loads(message)
+                if message_dict["message_type"] == MessageType.READY.value:
+                    self.assertEqual(
+                        message_dict["round"], users_ready_info[info_index]["round"]
+                    )
+                    self.assertEqual(
+                        message_dict["1p"], users_ready_info[info_index]["1p"]
+                    )
+                    self.assertEqual(
+                        message_dict["2p"], users_ready_info[info_index]["2p"]
+                    )
+                    info_index += 1
+                    has_ready_message = True
+            if has_ready_message is False:
+                self.assertTrue(False)
+
+    @patch("pong_game.module.GameSetValue.BALL_SPEED_Z", 300)
+    async def test_round_logic_test(self):
+        """
+        정상적인 로직으로 진행했을때 결승전까지 잘 마무리 되는지 테스트
+        """
+        users_info_test_tournament1 = [
+            {
+                "intra_id": self.room_1_owner_id,
+                "expected_player_number": PlayerNumber.PLAYER_1,
+            },
+            {
+                "intra_id": self.room_1_user1_id,
+                "expected_player_number": PlayerNumber.PLAYER_2,
+            },
+            {
+                "intra_id": self.room_1_user2_id,
+                "expected_player_number": PlayerNumber.PLAYER_3,
+            },
+            {
+                "intra_id": self.room_1_user3_id,
+                "expected_player_number": PlayerNumber.PLAYER_4,
+            },
+        ]
+
+        self.test_tournament1_communicators = await self.perform_test_sequence(
+            self.room_1_name, users_info_test_tournament1
+        )
+
+        users_ready_info_test_tournament1 = [
+            {
+                "message_type": MessageType.READY.value,
+                "round": "1",
+                "1p": self.room_1_owner_id,
+                "2p": self.room_1_user1_id,
+            },
+            {
+                "message_type": MessageType.READY.value,
+                "round": "1",
+                "1p": self.room_1_owner_id,
+                "2p": self.room_1_user1_id,
+            },
+            {
+                "message_type": MessageType.READY.value,
+                "round": "2",
+                "1p": self.room_1_user2_id,
+                "2p": self.room_1_user3_id,
+            },
+            {
+                "message_type": MessageType.READY.value,
+                "round": "2",
+                "1p": self.room_1_user2_id,
+                "2p": self.room_1_user3_id,
+            },
+        ]
+        await self.check_recieved_ready_messgae_valid(
+            users_ready_info=users_ready_info_test_tournament1,
+            communicators=self.test_tournament1_communicators,
+        )
+
+        await self.discard_all_message(
+            communicators=self.test_tournament1_communicators
+        )
+
+        # 접속 다 끊기
+        for communicator in self.test_tournament1_communicators:
+            await communicator.disconnect()
+
+        self.test_tournament1_communicators = []
+        for idx, (ready_info, user_info) in enumerate(
+            zip(users_ready_info_test_tournament1, users_info_test_tournament1), start=0
+        ):
+            user = await self.get_user(intra_id=user_info["intra_id"])
+            communicator = await self.connect_and_send_ready_data(
+                tournament_name=self.room_1_name,
+                user=user,
+                round=idx // 2 + 1,
+                ready_data=ready_info,
+            )
+            self.test_tournament1_communicators.append(communicator)
+
+        # start 메시지 잘 받는지 확인
+        start_reponse = await self.test_tournament1_communicators[0].receive_from()
+        start_reponse_dict = json.loads(start_reponse)
+        self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
+        self.assertEqual(start_reponse_dict["round"], "1")
+        start_reponse = await self.test_tournament1_communicators[1].receive_from()
+        start_reponse_dict = json.loads(start_reponse)
+        self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
+        self.assertEqual(start_reponse_dict["round"], "1")
+        start_reponse = await self.test_tournament1_communicators[2].receive_from()
+        start_reponse_dict = json.loads(start_reponse)
+        self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
+        self.assertEqual(start_reponse_dict["round"], "2")
+        start_reponse = await self.test_tournament1_communicators[3].receive_from()
+        start_reponse_dict = json.loads(start_reponse)
+        self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
+        self.assertEqual(start_reponse_dict["round"], "2")
+
+        await self.test_tournament1_communicators[0].send_to(
+            text_data=json.dumps(
+                {"message_type": "playing", "number": "player1", "input": "left_press"}
+            )
+        )
+
+        await self.test_tournament1_communicators[2].send_to(
+            text_data=json.dumps(
+                {"message_type": "playing", "number": "player1", "input": "left_press"}
+            )
+        )
+
+        while True:
+            user1_response = await self.test_tournament1_communicators[0].receive_from()
+            user1_dict = json.loads(user1_response)
+            print(user1_dict)
+            if (
+                user1_dict["message_type"] == "end"
+                or user1_dict["message_type"] == "stay"
+            ):
+                break
+
+        while True:
+            user2_response = await self.test_tournament1_communicators[1].receive_from()
+            user2_dict = json.loads(user2_response)
+            print(user2_dict)
+            if (
+                user2_dict["message_type"] == "end"
+                or user2_dict["message_type"] == "stay"
+            ):
+                break
+
+        while True:
+            user3_response = await self.test_tournament1_communicators[2].receive_from()
+            user3_dict = json.loads(user3_response)
+            print(user3_dict)
+            if (
+                user3_dict["message_type"] == "end"
+                or user3_dict["message_type"] == "stay"
+            ):
+                break
+
+        while True:
+            user4_response = await self.test_tournament1_communicators[3].receive_from()
+            user4_dict = json.loads(user4_response)
+            print(user4_dict)
+            if (
+                user4_dict["message_type"] == "end"
+                or user4_dict["message_type"] == "stay"
+            ):
+                break
+
+        await self.discard_all_message(self.test_tournament1_communicators)
+
+        await self.test_tournament1_communicators[1].send_to(
+            json.dumps(
+                {
+                    "message_type": "stay",
+                    "round": "1",
+                    "winner": "room_1_user1",
+                    "loser": "room_1_owner",
+                }
+            )
+        )
+
+        await self.test_tournament1_communicators[3].send_to(
+            json.dumps(
+                {
+                    "message_type": "stay",
+                    "round": "2",
+                    "winner": "room_1_user3",
+                    "loser": "room_1_user2",
+                }
+            )
+        )
+
+        # await self.discard_all_message(self.test_tournament1_communicators)
+
+        # 연결 끊기
+        for communicator in self.test_tournament1_communicators:
+            await communicator.disconnect()
+
+        self.test_tournament1_communicators = []
+
+        self.test_tournament1_communicators.append(
+            await self.connect_and_send_ready_data(
+                tournament_name=self.room_1_name,
+                user=await self.get_user(intra_id=self.room_1_user1_id),
+                round=3,
+                ready_data={
+                    "message_type": MessageType.READY.value,
+                    "round": "3",
+                    "1p": self.room_1_user1_id,
+                    "2p": self.room_1_user3_id,
+                },
+            )
+        )
+
+        self.test_tournament1_communicators.append(
+            await self.connect_and_send_ready_data(
+                tournament_name=self.room_1_name,
+                user=await self.get_user(intra_id=self.room_1_user3_id),
+                round=3,
+                ready_data={
+                    "message_type": MessageType.READY.value,
+                    "round": "3",
+                    "1p": self.room_1_user1_id,
+                    "2p": self.room_1_user3_id,
+                },
+            )
+        )
+
+        await self.discard_all_message(self.test_tournament1_communicators)
+        await self.test_tournament1_communicators[0].send_to(
+            json.dumps(
+                {
+                    "message_type": "stay",
+                    "round": "3",
+                    "winner": "room_1_user3",
+                    "loser": "room_1_user1",
+                }
+            )
+        )
+
+        a = await self.wait_for_tournament_data(
+            tournamnet_name=self.room_1_name, round=1
+        )
+        print(a.__dict__)
+        a = await self.wait_for_tournament_data(
+            tournamnet_name=self.room_1_name, round=2
+        )
+        print(a.__dict__)
+        a = await self.wait_for_tournament_data(
+            tournamnet_name=self.room_1_name, round=3
+        )
+        print(a.__dict__)
+        await self.discard_all_message(self.test_tournament1_communicators)

--- a/docs/tournament_game_socket.md
+++ b/docs/tournament_game_socket.md
@@ -79,6 +79,19 @@
 }
 ```
 
+### 7.1 [Back] 만약 wait 중에 플레이어 접속 종료 시
+
+- 접속 종료한 유저 정보 전달
+
+```json
+{
+    "message_type": "error",
+    "intra_id": "{접속 종료한 intra_id}",
+    "total": "{join_player_num}",
+    "number": "{player1 / player2 / player3 / player4}"
+}
+```
+
 ### 8. [Back] 인원이 모두 모이면 프론트한테 보내기
 
 ```json

--- a/docs/tournament_game_socket.md
+++ b/docs/tournament_game_socket.md
@@ -85,7 +85,7 @@
 
 ```json
 {
-    "message_type": "error",
+    "message_type": "wait",
     "intra_id": "{접속 종료한 intra_id}",
     "total": "{join_player_num}",
     "number": "{player1 / player2 / player3 / player4}"

--- a/makefile
+++ b/makefile
@@ -8,9 +8,13 @@ down:
 	docker-compose -f ./docker-compose.yml down
 
 test:
-	cd ./back/ && python3 manage.py test  --settings=back.test_settings
+
+	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameRoundConsumerTests --settings=back.test_settings
+#	cd ./back/ && python3 manage.py test pong_game.tests.GeneralGameConsumerTests.test_save_game_data_to_db --settings=back.test_settings
+#	cd ./back/ && python3 manage.py test  --settings=back.test_settings
 #	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameConsumerTests.test_disconnect_test2 --settings=back.test_settings
 #	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameConsumerTests.test_overflow_user_connection_test --settings=back.test_settings
+#	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameRoundConsumerTests --settings=back.test_settings
 
 
 


### PR DESCRIPTION
### Summary
- #42 에 맞혀서 테스트를 구현했습니다.
- 테스트를 구현하면서 생긴 에러, 버그들을 수정했습니다.
- 토너먼트 게임에서 프론트가 요구한 사항을 추가했습니다.
### Describe
#### #42 에 맞혀서 테스트를 구현했습니다.
- `TournamentGameRoundConsumerTests` 클래스를 만들고 그 클래스 내부에 `test_round_logic_test()` 함수를 추가했습니다.
##### 1. `TournamentGameRoundConsumerTests` 클래스
- `_test_user(), delete_test_user(), get_user()`
  - 유저를 생성, 삭제, 조회하는 함수입니다.
- `wait_for_tournament_data(),  get_tournament_data()`
  - 토너먼트의 데이터를 가져오는 함수로써 최대 1초까지 polling 형식으로 토너먼트 데이터를 가져옵니다.
- `setUp()`
  -  가짜 토너먼트 데이터를 ACTIVE_TOURNAMENTS에 주입합니다.
- `connect_and_echo_data()`
  - 연결하고 받은 메시지를 그대로 다시 보내는 함수입니다.
  - 토너먼트를 대기, 라운드를 두 단계로 나누면 대기에서 쓰이는 함수입니다.
- `connect_and_send_ready_data()`
  - 연결하고 매개변수로 받은 ready_data를 보내는 함수입니다.
  - 라운드 단계에서 쓰이는 함수입니다.
- `discard_all_message()`
  - 작성한 consumer 들은 receive를 받고 토너먼트나 플레이어 상태를 변경시킵니다.
  - 아직 receive를 덜 한 것들이 있으면 receive를 하는 함수입니다.
- `perform_test_sequence(), check_recieved_ready_messgae_valid()`
  - 토너먼트에서 대기 단계에서 라운드 단계 전까지 연결 및 테스트를 수행하는 함수입니다.
##### 2. `test_round_logic_test()`
- 저희가 예측하는 로직으로 진행했을 때 결승전까지 마무리되고 db에 저장이 잘 되는지 확인하는 테스트입니다.
- 빠른 테스트를 위해서 공 속도를 30배, 1p 패들을 왼쪽으로 옮겼습니다.
#### 테스트를 구현하면서 생긴 에러, 버그들을 수정했습니다.
##### 1. `tournamentGameRoundConsumer` 라우팅 추가
- consumer만 존재하고 관련된 라우팅이 없어서 추가했습니다.
##### 2. `json`으로 반환하도록 수정
- 몇몇 반환함수가 json을 반환하지 않아서 수정했습니다.
##### 3. `connect`, `receive` 할 때 1라운드, 2라운드일 때 로직과 3라운드일 때 로직으로 구분했습니다.
- 수정 전은 구별하지 않았는데 1라운드, 2라운드를 진행하면서 TournamentStatus가 READY에서 PLAYING으로 변경됨에 따라 로직을 구분했습니다.
##### 4. `save_game_data_to_db()` 수정
- 만들어둔 `get_db_datas()`를 사용해서 수정했습니다.
##### 5. `self.game_loop_task`가 None이 아닌지 확인하는 조건문을 추가했습니다.
- disconnect 할 때 게임 루프는 플레이어마다 생기는 게 아닌 게임마다(라운드) 한 개가 생기므로 게임 루프를 가지지 않는 플레이어가 종료될 때의 예외처리를 추가했습니다.
##### 6. `ROUND_READ` 추가
- round에서 is_all_ready를 검사할 때 READY가 아닌 ROUND_READY를 검사하도록 했습니다.
##### 7. `await` 키워드 추가
- await 키워드가 빠진 곳이 있어서 추가했습니다.
##### 8. `Player` 객체가 실제 게임 위치를 가지도록 수정
- 이전 브랜치에서 `Player()` 객체를 생성할 때, 각자의 player number(ex. player1, player2, player3, player4)에 해당하는 수를 넣었습니다. 하지만 `Player()` 객체는 실제 경기 중에 player의 위치(ex. 1p, 2p)를 받기에 테스트에서 에러를 발견했습니다. 이에 입력값을 수정했습니다.
- 또한 1,2라운드가 끝나고 3라운드가 되었을 때 플레이하는 위치가 바뀔 수 있습니다. (1라운드에서 1p인 유저가 3라운드에선 2p가 될 수 있습니다.) 그렇기에 이를 변경하는 함수를 추가하고 적용했습니다.

##### 9. `Paddle` 객체 설정을 초기화하는 함수 추가
- 플레이어가 가지는 패들이 다음 경기 전에 위치가 초기화 되지 않는 점이 있었습니다. 또한 8번 문제와 마찬가지로 현재 플레이어의 위치에 따라 패들의 값이 조정되어야 하는 문제도 있었습니다.
- 이에 `Player` 객체와 마찬가지로 `Paddle` 객체 역시 초기화하는 함수를 만들었습니다.



#### 토너먼트 게임에서 프론트가 요구한 사항을 추가했습니다.
##### 1. 토너먼트 시작을 기다리는 중 플레이어가 나갔을 때 동작 추가
- disconnect 하면 나간 인원과 줄어든 현재 인원을 전송합니다.
### TODO
- general_game, tournament 게임 둘 다 종료 후 유저의 승패를 추가하는 기능이 빠져 있습니다.
- `test_round_logic_test()`은 단순히 저희가 생각하는 happy path를 따라갈 때의 로직을 테스트 한 것입니다.
- 그 외 라운드 참가자가 게임을 도중에 나가거나, 연결이 끊기는 상황들은 테스트하지 못했습니다. 
