### PR TITLE
[Back-53] user win loss update after game finish

### DIFF
--- a/back/accounts/models.py
+++ b/back/accounts/models.py
@@ -58,7 +58,7 @@ class Users(AbstractBaseUser, PermissionsMixin):
     is_staff: bool = models.BooleanField(
         default=False
     )  # 추가: 관리자 사이트에 로그인하기 위해 필요
-    is_active: bool = models.BooleanField(default=True)  # 추가: 사용자가 활성 상태인지
+    is_active: bool = models.BooleanField(default=False)  # 추가: 사용자가 활성 상태인지
 
     objects: UserManager = UserManager()
 

--- a/back/accounts/tests.py
+++ b/back/accounts/tests.py
@@ -152,3 +152,112 @@ class HouseViewSetTest(APITestCase):
         for idx, (key, value) in enumerate(response.data.items()):
             self.assertEqual(key, house[idx])
             self.assertEqual(value, rate[idx])
+
+
+class LoginLogoutUserStatusTest(APITestCase):
+    def setUp(self):
+        """
+        test 유저 생성
+        """
+        self.user = get_user_model().objects.create_user(
+            intra_id="1", is_test_user=True
+        )
+        self.login_url = reverse(
+            "test_user_login", kwargs={"intra_id": self.user.intra_id}
+        )
+        self.logout_url = reverse("logout")
+
+    def test_login_logout_user_status(self):
+        """
+        login시 status가 online인지 확인
+        logout시 status가 offline인지 확인
+        """
+        # active 초기값 False 확인
+        self.assertEqual(self.user.is_active, False)
+
+        # login
+        response = self.client.get(self.login_url)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.is_active, True)
+
+        # logout
+        response = self.client.get(self.logout_url)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.is_active, False)
+
+    def test_double_login(self):
+        """
+        login double로 해도 올바른 상태값 반환하는지
+        """
+        # active 초기값 False 확인
+        self.assertEqual(self.user.is_active, False)
+
+        # login
+        response = self.client.get(self.login_url)
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.is_active, True)
+
+        # double login
+        response = self.client.get(self.login_url)
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.is_active, True)
+
+    def test_double_logout(self):
+        """
+        logout double로 해도 올바른 상태값 반환하는지
+        """
+        # active 초기값 False 확인
+        self.assertEqual(self.user.is_active, False)
+
+        # login
+        response = self.client.get(self.login_url)
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.is_active, True)
+
+        # logout
+        url = reverse("logout")
+        response = self.client.get(self.logout_url)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.is_active, False)
+
+        # double logout
+        response = self.client.get(self.logout_url)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.is_active, False)
+
+    def test_login_logout_login(self):
+        """
+        login_logout_login 할때
+        """
+        # active 초기값 False 확인
+        self.assertEqual(self.user.is_active, False)
+
+        # login
+        response = self.client.get(self.login_url)
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.is_active, True)
+
+        # logout
+        response = self.client.get(self.logout_url)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.is_active, False)
+
+        # login
+        response = self.client.get(self.login_url)
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.is_active, True)

--- a/back/accounts/urls.py
+++ b/back/accounts/urls.py
@@ -18,6 +18,10 @@ urlpatterns = [
     path("login/42/callback/", views.CallbackAPIView.as_view()),
     path("logout/", logout_view, name="logout"),
     # TODO test용 삭제
-    path("login/<str:intra_id>/", views.TestAccountLogin.as_view()),
+    path(
+        "login/<str:intra_id>/",
+        views.TestAccountLogin.as_view(),
+        name="test_user_login",
+    ),
     path("house/", views.HouseViewSet.as_view({"get": "list"}), name="house"),
 ]

--- a/back/accounts/views.py
+++ b/back/accounts/views.py
@@ -199,6 +199,8 @@ class CallbackAPIView(APIView):
             user_instance.save()
         # login
         login(request, user_instance)
+        user_instance.is_active = True
+        user_instance.save()
         return redirect(BASE_FULL_IP)
 
     def _get_access_token(self, request) -> str:
@@ -222,6 +224,11 @@ class CallbackAPIView(APIView):
 
 
 def logout_view(request) -> redirect:
+    if request.user.is_authenticated:
+        user_instance = request.user
+        user_instance.is_active = False
+        user_instance.save()
+
     logout(request)
     return redirect(BASE_FULL_IP)
 
@@ -265,6 +272,8 @@ class TestAccountLogin(APIView):
         try:
             user_instance = Users.objects.get(intra_id=kwargs["intra_id"])
             if user_instance.is_test_user:
+                user_instance.is_active = True
+                user_instance.save()
                 login(request, user_instance)
             else:
                 print("Error: 허용 되지 않은 유저입니다.")

--- a/back/accounts/views.py
+++ b/back/accounts/views.py
@@ -21,6 +21,8 @@ HOUSE = {
     "Gon": HouseEnum.SLYTHERIN,
 }
 
+BASE_FULL_IP = f"https://{os.environ.get('BASE_IP')}/"
+
 
 # https://squirmm.tistory.com/entry/Django-DRF-Method-Override-%EB%B0%A9%EB%B2%95
 class UsersViewSet(viewsets.ModelViewSet):
@@ -140,7 +142,7 @@ class UsersDetailViewSet(viewsets.ModelViewSet):
 class Login42APIView(APIView):
     def get(self, request, *args, **kwargs) -> redirect:
         if request.user.is_authenticated:
-            return redirect("https://127.0.0.1/")
+            return redirect(BASE_FULL_IP)
 
         client_id = os.environ.get("CLIENT_ID")
         response_type = "code"
@@ -156,7 +158,7 @@ class Login42APIView(APIView):
 class CallbackAPIView(APIView):
     def get(self, request, *args, **kwargs) -> redirect:
         if request.user.is_authenticated:
-            return redirect("https://127.0.0.1/")
+            return redirect(BASE_FULL_IP)
 
         if request.session.get("state") and not request.GET.get(
             "state"
@@ -171,7 +173,7 @@ class CallbackAPIView(APIView):
         )
         # 42 api에 정보 요청 실패
         if user_info_request.status_code != 200:
-            return redirect("https://127.0.0.1/")
+            return redirect(BASE_FULL_IP)
 
         user_info = user_info_request.json()
         coalition_info_request = requests.get(
@@ -197,7 +199,7 @@ class CallbackAPIView(APIView):
             user_instance.save()
         # login
         login(request, user_instance)
-        return redirect("https://127.0.0.1/")
+        return redirect(BASE_FULL_IP)
 
     def _get_access_token(self, request) -> str:
         grant_type = "authorization_code"
@@ -221,7 +223,7 @@ class CallbackAPIView(APIView):
 
 def logout_view(request) -> redirect:
     logout(request)
-    return redirect("https://127.0.0.1/")
+    return redirect(BASE_FULL_IP)
 
 
 class HouseViewSet(viewsets.ModelViewSet):
@@ -259,16 +261,14 @@ class TestAccountLogin(APIView):
         GET method override
         """
         if request.user.is_authenticated:
-            return redirect(
-                f"http://127.0.0.1:8000/api/v1/users/{request.user.intra_id}/"
-            )
+            return redirect(BASE_FULL_IP)
         try:
             user_instance = Users.objects.get(intra_id=kwargs["intra_id"])
             if user_instance.is_test_user:
                 login(request, user_instance)
             else:
                 print("Error: 허용 되지 않은 유저입니다.")
-            return redirect("https://127.0.0.1/")
+            return redirect(BASE_FULL_IP)
         except Users.DoesNotExist:
             print("Error: 사용자를 찾을 수 없습니다.")
-            return redirect("https://127.0.0.1/")
+            return redirect(BASE_FULL_IP)

--- a/back/back/settings.py
+++ b/back/back/settings.py
@@ -32,6 +32,8 @@ DEBUG = True
 
 ALLOWED_HOSTS = ["*"]
 
+# frontend 요구 사항
+CSRF_TRUSTED_ORIGINS = [f"https://{os.environ.get("BASE_IP")}/"]
 
 # Application definition
 

--- a/back/back/settings.py
+++ b/back/back/settings.py
@@ -33,7 +33,7 @@ DEBUG = True
 ALLOWED_HOSTS = ["*"]
 
 # frontend 요구 사항
-CSRF_TRUSTED_ORIGINS = [f"https://{os.environ.get("BASE_IP")}/"]
+CSRF_TRUSTED_ORIGINS = [f"https://{os.environ.get('BASE_IP')}/"]
 
 # Application definition
 

--- a/back/pong_game/module/GeneralGame.py
+++ b/back/pong_game/module/GeneralGame.py
@@ -9,6 +9,7 @@ from .GameSetValue import (
     PADDLE_WIDTH,
     MessageType,
     GameTimeType,
+    MAX_SCORE,
 )
 
 
@@ -196,6 +197,14 @@ class GeneralGame:
             "player1_score": self.score1,
             "player2_score": self.score2,
         }
+
+    def get_winner_loser_intra_id(self) -> tuple:
+        if self.score1 == MAX_SCORE:
+            return self.player1.get_intra_id(), self.player2.get_intra_id()
+        elif self.score2 == MAX_SCORE:
+            return self.player2.get_intra_id(), self.player1.get_intra_id()
+        else:
+            return None, None
 
     def set_player(self, player_intra_id: str) -> None:
         if self.player1 is None:

--- a/back/pong_game/module/Tournament.py
+++ b/back/pong_game/module/Tournament.py
@@ -143,6 +143,9 @@ class Tournament:
         db_data["is_final"] = round_number == 3
         return db_data
 
+    def get_winner_loser_intra_ids(self, round_number: int) -> tuple:
+        return self.round_list[round_number - 1].get_winner_loser_intra_id()
+
     def set_status(self, status: TournamentStatus) -> None:
         self.status = status
 

--- a/makefile
+++ b/makefile
@@ -12,8 +12,8 @@ test:
 	cd ./back/ && python3 manage.py test friendrequests --settings=back.test_settings
 	cd ./back/ && python3 manage.py test games --settings=back.test_settings
 	cd ./back/ && python3 manage.py test accounts --settings=back.test_settings
-
-#	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameRoundConsumerTests --settings=back.test_settings
+	cd ./back/ && python3 manage.py test pong_game.tests.GeneralGameConsumerTests.test_save_game_data_to_db --settings=back.test_settings
+	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameRoundConsumerTests --settings=back.test_settings
 #	cd ./back/ && python3 manage.py test pong_game.tests.GeneralGameConsumerTests.test_save_game_data_to_db --settings=back.test_settings
 #	cd ./back/ && python3 manage.py test  --settings=back.test_settings
 #	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameConsumerTests.test_disconnect_test2 --settings=back.test_settings

--- a/makefile
+++ b/makefile
@@ -9,7 +9,11 @@ down:
 
 test:
 
-	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameRoundConsumerTests --settings=back.test_settings
+	cd ./back/ && python3 manage.py test friendrequests --settings=back.test_settings
+	cd ./back/ && python3 manage.py test games --settings=back.test_settings
+	cd ./back/ && python3 manage.py test accounts --settings=back.test_settings
+
+#	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameRoundConsumerTests --settings=back.test_settings
 #	cd ./back/ && python3 manage.py test pong_game.tests.GeneralGameConsumerTests.test_save_game_data_to_db --settings=back.test_settings
 #	cd ./back/ && python3 manage.py test  --settings=back.test_settings
 #	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameConsumerTests.test_disconnect_test2 --settings=back.test_settings


### PR DESCRIPTION
### Summary
- 하드 코딩된 주소 env에서 받아오도록 수정했습니다.
- login, log out 시 user.is_active 상태 변경 기능 추가했습니다.
- 게임 승패시 유저 데이터 db 업데이트 기능 추가했습니다.
- 관련된 테스트 추가했습니다.
### Describe
#### 하드 코딩된 주소 env에서 받아오도록 수정했습니다.
- 하드 코딩된 https://127.0.0.1/를 env에 있는 BASE_IP를 받아와서 redirect 하도록 수정했습니다.
- 나중에 remote 모듈 할 때 도움될 것 같습니다.
#### login, log out 시 user.is_active 상태 변경 기능 추가했습니다.
##### 1. login, log out 시 user.is_active True, False로 변경
- 프론트에서 patch로 요청하는 게 아닌 login 하면 알아서 바뀌도록 수정해달라고 해서 기능을 추가했습니다.
##### 2. user의 is_active의 기본값을 False로 변경
- login 할 때만 True로 변경하도록 했습니다.
#### 게임 승패시 유저 데이터 db 업데이트 기능 추가했습니다.
##### 1. Game에 get_winner_loser_intra_id(self) 추가
- GameSetValue에서 MAX_SCORE를 가져와서 이 점수랑 일치하는 플레이어 아이디를 winner_id, 아닌 플레이어 아이디는 loser_id로 반환하게 했습니다.
- 둘 다 MAX_SCORE에 도달하지 못한 경우는 에러라 생각해 None을 반환하게 했습니다.
##### 2. Tournament에 get_winner_loser_intra_ids(self, round_number: int) 추가
- 1의 get_winner_loser_intra_id(self)랑 비슷한 함수로서 round_number에 맞는 winner_id, loser_id를 반환합니다
##### 3. F() 표현식
- F() log out 시 데이터베이스 레벨에서 수행돼서 레이스 컨디션 문제를 방지할 수 있다고 해서 추가했습니다.
```
Users.objects.filter(intra_id=winner_id).update(
   win_count=F(＂win_count＂) + 1
)
```
이것을 풀어쓰면
```
winner = Users.objects.get(intra_id=winner_intra_id)
winner.win_count += 1
winner.save()
````
이것과 비슷합니다.(F()는 데이터베이스 레벨에서 수행되므로)
#### 관련된 테스트 추가했습니다.
##### 1. LoginLogoutUserStatusTest
- login, logout 했을 때 user의 is_active를 변경하는지
##### 2. game 관련 테스트는 기존의 있는 테스트에서 user의 db를 변경하는지만 마지막에 추가했습니다.
- pong_game.tests.GeneralGameConsumerTests.test_save_game_data_to_db과  pong_game.tests.TournamentGameRoundConsumerTests 참고 바랍니다.
### TODO
- 아직 프론트 상태에서 user의 is_active 상태를 표현하는 게 구현이 안 돼 있습니다.
  - 나중에 프론트에서 구현되면 확인이 필요합니다.
- OAUTH 유저는 login, logout시 is_active 테스트 못했습니다.
  - 테스트 코드가 복잡할 것 같아서 같은 로직인 테스트 유저만 테스트했습니다.
  - 다른 문제는 없을 것으로 예상되나 합쳐질 때 확인이 필요합니다.
- 아직 토너먼트 disconnect 테스트가 없습니다.