### PR TITLE
[BACK-54] create-user-game-stat

### DIFF
--- a/back/accounts/tests.py
+++ b/back/accounts/tests.py
@@ -1,4 +1,6 @@
 from django.contrib.auth import get_user_model
+from django.utils.timezone import make_aware
+from datetime import datetime
 from rest_framework.test import APITestCase
 from rest_framework import status
 from django.urls import reverse
@@ -124,31 +126,83 @@ class UsersDetailViewSetTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
-class HouseViewSetTest(APITestCase):
+class ChartViewSetTest(APITestCase):
     def setUp(self):
-        self.user = get_user_model().objects.create_user(
+        self.user1 = get_user_model().objects.create_user(
             intra_id="1", house="RA", win_count=7, lose_count=3
         )
-        self.user = get_user_model().objects.create_user(
+        self.user2 = get_user_model().objects.create_user(
             intra_id="2", house="GR", win_count=6, lose_count=4
         )
-        self.user = get_user_model().objects.create_user(
+        self.user3 = get_user_model().objects.create_user(
             intra_id="3", house="HU", win_count=5, lose_count=5
         )
-        self.user = get_user_model().objects.create_user(
+        self.user4 = get_user_model().objects.create_user(
             intra_id="4", house="SL", win_count=4, lose_count=6
         )
+        self.create_url = reverse("general_game_logs")
+        self.start_time = make_aware(datetime(2021, 1, 1, 0, 0, 0))
+        self.end_time = make_aware(datetime(2021, 1, 2, 1, 0, 0))
 
     def test_get_house_with_authenticate(self):
         """
         기숙사 정보를 가져오는 테스트
         """
-        self.client.force_authenticate(user=self.user)
-        url = reverse("house")
+        self.client.force_authenticate(user=self.user1)
+
+        data = {
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "player1_intra_id": self.user1.intra_id,
+            "player2_intra_id": self.user2.intra_id,
+            "player1_score": 5,
+            "player2_score": 3,
+        }
+        self.client.post(self.create_url, data)
+        data = {
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "player1_intra_id": self.user1.intra_id,
+            "player2_intra_id": self.user3.intra_id,
+            "player1_score": 5,
+            "player2_score": 3,
+        }
+        self.client.post(self.create_url, data)
+        data = {
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "player1_intra_id": self.user4.intra_id,
+            "player2_intra_id": self.user1.intra_id,
+            "player1_score": 5,
+            "player2_score": 3,
+        }
+        self.client.post(self.create_url, data)
+        data = {
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "player1_intra_id": self.user1.intra_id,
+            "player2_intra_id": self.user4.intra_id,
+            "player1_score": 5,
+            "player2_score": 3,
+        }
+        self.client.post(self.create_url, data)
+
+        url = reverse("chart")
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(response.data["win_count"], 3)
+        self.assertEqual(response.data["lose_count"], 1)
+        self.assertEqual(response.data["total_count"], 4)
+
+        rate = (0.75, 0.0, 1.0, 1.0, 0.5)
+        house = ("total", "RA", "GR", "HU", "SL")
+        for idx, (key, value) in enumerate(response.data["rate"].items()):
+            self.assertEqual(key, house[idx])
+            self.assertEqual(value, rate[idx])
+
         rate = (0.7, 0.6, 0.5, 0.4)
         house = ("RA", "GR", "HU", "SL")
-        for idx, (key, value) in enumerate(response.data.items()):
+        for idx, (key, value) in enumerate(response.data["house"].items()):
             self.assertEqual(key, house[idx])
             self.assertEqual(value, rate[idx])

--- a/back/accounts/urls.py
+++ b/back/accounts/urls.py
@@ -19,5 +19,5 @@ urlpatterns = [
     path("logout/", logout_view, name="logout"),
     # TODO test용 삭제
     path("login/<str:intra_id>/", views.TestAccountLogin.as_view()),
-    path("house/", views.HouseViewSet.as_view({"get": "list"}), name="house"),
+    path("chart/", views.ChartViewSet.as_view({"get": "list"}), name="chart"),
 ]

--- a/back/accounts/views.py
+++ b/back/accounts/views.py
@@ -6,13 +6,18 @@ from rest_framework.views import APIView
 from django.shortcuts import redirect
 from django.core.files.base import ContentFile
 from django.conf import settings
+from django.db.models import Q
 from .serializers import UsersSerializer, UsersDetailSerializer
 from .models import Users, HouseEnum
 from rest_framework.permissions import IsAuthenticated
 from django.contrib.auth import login
 from rest_framework.exceptions import ValidationError, PermissionDenied
 from django.contrib.auth import logout
-
+from games.models import GeneralGameLogs, TournamentGameLogs
+from games.serializers import (
+    GeneralGameLogsListSerializer,
+    TournamentGameLogsListSerializer,
+)
 
 HOUSE = {
     "Gam": HouseEnum.RAVENCLAW,
@@ -224,17 +229,68 @@ def logout_view(request) -> redirect:
     return redirect("https://127.0.0.1/")
 
 
-class HouseViewSet(viewsets.ModelViewSet):
+class ChartViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
     queryset = Users.objects.all()
     serializer_class: UsersSerializer = UsersSerializer
     http_method_names = ["get"]
+
+    @staticmethod
+    def _add_data(
+        request: requests, data: dict, win_logs: dict, lose_logs: dict
+    ) -> None:
+        for logs in data:
+            if logs["player1"]["intra_id"] == request.user.intra_id:
+                if logs["player1_score"] > logs["player2_score"]:
+                    win_logs[logs["player2"]["house"]] += 1
+                else:
+                    lose_logs[logs["player2"]["house"]] += 1
+            else:
+                if logs["player2_score"] > logs["player1_score"]:
+                    win_logs[logs["player1"]["house"]] += 1
+                else:
+                    lose_logs[logs["player1"]["house"]] += 1
 
     def list(self, request, *args, **kwargs) -> Response:
         """
         GET method override
         """
         data = {}
+
+        # 사용자의 각 기숙사 별 대결 승률
+        win_logs = {"RA": 0, "GR": 0, "HU": 0, "SL": 0}
+        lose_logs = {"RA": 0, "GR": 0, "HU": 0, "SL": 0}
+        general_game = GeneralGameLogs.objects.all()
+        general_game_queryset = general_game.filter(
+            Q(player1=request.user.user_id) | Q(player2=request.user.user_id)
+        )
+        general_game_serializer = GeneralGameLogsListSerializer(
+            general_game_queryset, many=True
+        )
+        self._add_data(request, general_game_serializer.data, win_logs, lose_logs)
+
+        tournament = TournamentGameLogs.objects.all()
+        tournament_queryset = tournament.filter(
+            Q(player1=request.user.user_id) | Q(player2=request.user.user_id)
+        )
+        tournament_serializer = TournamentGameLogsListSerializer(
+            tournament_queryset, many=True
+        )
+        self._add_data(request, tournament_serializer.data, win_logs, lose_logs)
+
+        data["win_count"] = sum(win_logs.values())
+        data["lose_count"] = sum(lose_logs.values())
+        data["total_count"] = data["win_count"] + data["lose_count"]
+        data["rate"] = {
+            "total": data["win_count"] / (data["total_count"] + 1e-18),
+            "RA": win_logs["RA"] / (win_logs["RA"] + lose_logs["RA"] + 1e-18),
+            "GR": win_logs["GR"] / (win_logs["GR"] + lose_logs["GR"] + 1e-18),
+            "HU": win_logs["HU"] / (win_logs["HU"] + lose_logs["HU"] + 1e-18),
+            "SL": win_logs["SL"] / (win_logs["SL"] + lose_logs["SL"] + 1e-18),
+        }
+
+        # 각 기숙사 별 승률
+        data["house"] = {}
         for house in ("RA", "GR", "HU", "SL"):
             queryset = UsersViewSet.queryset.filter(house=house)
             serializer = UsersSerializer(queryset, many=True)
@@ -247,7 +303,8 @@ class HouseViewSet(viewsets.ModelViewSet):
                 if total_win_count + total_lose_count
                 else 0
             )
-            data[house] = rate
+            data["house"][house] = rate
+
         return Response(data)
 
 


### PR DESCRIPTION
### Summary

- 개인 승률과 기숙사별 승률을 전달하는 api를 만들었습니다.
- 그리고 그에 따른 간단한 테스트를 만들었습니다.


### Describe

- `api/v1/chart/` url에 요청하면 아래와 같은 데이터를 전달하도록 동작을 추가했습니다.

```
{
    "win_count": 1,                    # 유저가 이긴 횟수
    "lose_count": 1,                   # 유저가 진 횟수
    "total_count": 2,                  # 유저가 한 모든 게임 횟수
    "rate": {
        "total": 0.49999750001249993,  # 유저 전체 게임 승률
        "RA": 0.0,                     # 유저가 RA와 게임에서 승률
        "GR": 0.49999750001249993,     # 유저가 GR과 게임에서 승률
        "HU": 0.0,                     # 유저가 HU과 게임에서 승률
        "SL": 0.0                      # 유저가 SL과 게임에서 승률
    },
    "house": {
        "RA": 0.4,                     # RA 기숙사의 승률
        "GR": 0.8175,                  # GR 기숙사의 승률
        "HU": 0.8301886792452831,      # HU 기숙사의 승률
        "SL": 0.3125                   # SL 기숙사의 승률
    }
}
```

- 기존 house url을 chart url로 변경했습니다.


### TODO

- 프론트에서 필요한 데이터가 추가로 생길 시, 더 추가해야 합니다.