### PR TITLE
[Back-58] channel name internationalization

### DIFF
--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import json
 import uuid
 from typing import Deque
@@ -334,8 +335,12 @@ class TournamentGameConsumer(AsyncWebsocketConsumer):
                 "tournament_name"
             ]
             self.group_name_prefix = f"tournament_{self.tournament_name}"
-            self.group_name_a = self.group_name_prefix + "a"
-            self.group_name_b = self.group_name_prefix + "b"
+            self.group_name_a = hashlib.md5(
+                (self.group_name_prefix + "a").encode("utf-8")
+            ).hexdigest()
+            self.group_name_b = hashlib.md5(
+                (self.group_name_prefix + "b").encode("utf-8")
+            ).hexdigest()
             self.tournament = ACTIVE_TOURNAMENTS.get(self.tournament_name)
         if (
             self.tournament is not None


### PR DESCRIPTION
### Summary
- 토너먼트 네임이 영어가 아니여도 가능하게 수정했습니다.
### Describe
#### 토너먼트 네임이 영어가 아니여도 가능하게 수정했습니다.
- 프론트에서 테스트를 하는 중 토너먼트 네임이 영어만 가능하다는것을 알게 되었습니다.
- 다중 언어를 지원하는데 영어만 지원하는건 이상하다고 생각해서 수정했습니다.
##### md5
- md5는 빠르지만 너무 빠른 속도 때문에 보안적으로 취약합니다.
- 하지만 채널네임에서 보안은 상관이 없기 때문에 가볍고 빠른 해쉬 함수인 md5를 선택했습니다.
### TODO
- 게임 종료 후 채널네임이 일본어, 한국어, 20글자가 넘는 경우등 잘 저장이 되는지 테스트가 필요합니다.
- 글자 수가  tournament_name: str = models.CharField(max_length=20) 이런식으로 되어 있어서 백엔드나 프론트엔드에서 검증 로직이 필요할 것 같습니다.

