### PR TITLE
[Back-59] fix channel name internationalization

### DIFF
--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -463,8 +463,13 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
             self.tournament = ACTIVE_TOURNAMENTS.get(self.tournament_name)
             self.round_number = int(self.scope["url_route"]["kwargs"]["round"])
             self.round = self.tournament.get_round(self.round_number)
-            self.game_group_name = self.tournament_name + "_" + str(self.round_number)
-            self.tournament_broadcast = self.tournament_name + "_broadcast"
+
+            self.game_group_name = hashlib.md5(
+                (self.tournament_name + "_" + str(self.round_number)).encode("utf-8")
+            ).hexdigest()
+            self.tournament_broadcast = hashlib.md5(
+                (self.tournament_name + "_broadcast").encode("utf-8")
+            ).hexdigest()
             # TODO if 문 간소화 by myko
             if (
                 self.tournament is not None
@@ -624,7 +629,9 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
                 )
         else:
             round1, round2 = self.tournament.get_round(1), self.tournament.get_round(2)
-            self.winner_group = self.tournament_name + "_winner"
+            self.winner_group = hashlib.md5(
+                (self.tournament_name + "_winner").encode("utf-8")
+            ).hexdigest()
             await self.channel_layer.group_add(self.winner_group, self.channel_name)
             if (
                 round1.get_status() == PlayerStatus.END

--- a/back/pong_game/tests.py
+++ b/back/pong_game/tests.py
@@ -1067,7 +1067,7 @@ class TournamentGameRoundConsumerTests(TestCase):
     expected_tournaments_data: list[dict[str, str]]
     TEST_TOURNAMENTS_INFO = [
         {
-            "tournament_name": "test_tournament1",
+            "tournament_name": "한글",
             "create_user_intra_id": "room_1_owner",
             "wait_num": "1",
         },
@@ -1080,7 +1080,7 @@ class TournamentGameRoundConsumerTests(TestCase):
 
     def __init__(self, methodName: str = ...):
         super().__init__(methodName)
-        self.room_1_name = "test_tournament1"
+        self.room_1_name = "한글"
         self.room_2_name = "test_tournament2"
         self.room_1_owner_id = "room_1_owner"
         self.room_1_user1_id = "room_1_user1"
@@ -1311,6 +1311,10 @@ class TournamentGameRoundConsumerTests(TestCase):
         for idx, (ready_info, user_info) in enumerate(
             zip(users_ready_info_test_tournament1, users_info_test_tournament1), start=0
         ):
+            # if idx == 0 or idx == 3:
+            #     round = 1
+            # else:
+            #     round = 2
             user = await self.get_user(intra_id=user_info["intra_id"])
             communicator = await self.connect_and_send_ready_data(
                 tournament_name=self.room_1_name,


### PR DESCRIPTION
### Summary
- TournamentGameRoundConsumer 의 group_name도 hash로 수정했습니다.
- TournamentGameRoundConsumerTests를 수정했습니다.
### Describe
#### TournamentGameRoundConsumer 의 group_name도 hash로 수정했습니다.
- #49 에서 group_name을 hash함수를 사용했습니다.
- 하지만 다른 consumer에서 적용이 안 된 곳이 있어서 hash 함수를 적용했습니다.
#### TournamentGameRoundConsumerTests를 수정했습니다.
- 기존 토너먼트 정상적 로직 테스트에서 토너먼트 네임만 "한글"로 바꿨습니다.