### PR TITLE
[Back-61] create me api

### DIFF
--- a/back/games/tests.py
+++ b/back/games/tests.py
@@ -164,6 +164,41 @@ class GeneralGameLogsViewSetTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
+class GeneralGameLogsListMeViewSetTest(APITestCase):
+    def setUp(self):
+        self.user1 = Users.objects.create_user(intra_id="user1")
+        self.user2 = Users.objects.create_user(intra_id="user2")
+        self.user3 = Users.objects.create_user(intra_id="user3")
+        # 게임 로그 URL
+        self.list_url = reverse("general_game_me_logs")
+        GeneralGameLogs.objects.create(
+            start_time=make_aware(datetime(2021, 1, 1, 0, 0, 0)),
+            end_time=make_aware(datetime(2021, 1, 2, 1, 0, 0)),
+            player1=self.user1,
+            player2=self.user2,
+            player1_score=5,
+            player2_score=3,
+        )
+        GeneralGameLogs.objects.create(
+            start_time=make_aware(datetime(2021, 1, 1, 0, 0, 0)),
+            end_time=make_aware(datetime(2021, 1, 2, 1, 0, 0)),
+            player1=self.user1,
+            player2=self.user3,
+            player1_score=5,
+            player2_score=3,
+        )
+
+    def test_get_general_game_log_with_me(self):
+        """
+        get으로 자신의 로그를 가져오는지 테스트
+        """
+        self.client.force_authenticate(user=self.user1)
+        response = self.client.get(self.list_url)
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0]["player1"]["intra_id"], self.user1.intra_id)
+        self.assertEqual(response.data[1]["player1"]["intra_id"], self.user1.intra_id)
+
+
 class TournamentGameLogsViewSetTest(APITestCase):
     def setUp(self):
         # 네 명의 사용자 생성
@@ -411,3 +446,44 @@ class TournamentGameLogsViewSetTest(APITestCase):
         }
         response = self.client.post(self.create_log, data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+class TournamentGameLogsListMeViewSetTest(APITestCase):
+    def setUp(self):
+        self.user1 = Users.objects.create_user(intra_id="user1")
+        self.user2 = Users.objects.create_user(intra_id="user2")
+        self.user3 = Users.objects.create_user(intra_id="user3")
+        # 게임 로그 URL
+        self.list_url = reverse("tournament_game_me_logs")
+        TournamentGameLogs.objects.create(
+            start_time=make_aware(datetime(2021, 1, 1, 0, 0, 0)),
+            end_time=make_aware(datetime(2021, 1, 2, 1, 0, 0)),
+            player1=self.user1,
+            player2=self.user2,
+            player1_score=5,
+            player2_score=3,
+            tournament_name="test",
+            round=1,
+            is_final=False,
+        )
+        TournamentGameLogs.objects.create(
+            start_time=make_aware(datetime(2021, 1, 1, 0, 0, 0)),
+            end_time=make_aware(datetime(2021, 1, 2, 1, 0, 0)),
+            player1=self.user1,
+            player2=self.user3,
+            player1_score=5,
+            player2_score=3,
+            tournament_name="test",
+            round=3,
+            is_final=True,
+        )
+
+    def test_get_general_game_log_with_me(self):
+        """
+        get으로 자신의 로그를 가져오는지 테스트
+        """
+        self.client.force_authenticate(user=self.user1)
+        response = self.client.get(self.list_url)
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0]["player1"]["intra_id"], self.user1.intra_id)
+        self.assertEqual(response.data[1]["player1"]["intra_id"], self.user1.intra_id)

--- a/back/games/urls.py
+++ b/back/games/urls.py
@@ -14,6 +14,11 @@ urlpatterns = [
         name="general_game_all_logs",
     ),
     path(
+        "general_game_logs/me/",
+        views.GeneralGameLogsListMeViewSet.as_view({"get": "list"}),
+        name="general_game_me_logs",
+    ),
+    path(
         "general_game_logs/users/<str:intra_id>/",
         views.GeneralGameLogsListViewSet.as_view({"get": "list"}),
         name="general_game_user_logs",
@@ -27,6 +32,11 @@ urlpatterns = [
         "tournament_game_logs/all/",
         views.TournamentGameLogsListViewSet.as_view({"get": "list"}),
         name="tournament_game_all_logs",
+    ),
+    path(
+        "tournament_game_logs/me/",
+        views.TournamentGameLogsListMeViewSet.as_view({"get": "list"}),
+        name="tournament_game_me_logs",
     ),
     path(
         "tournament_game_logs/users/<str:intra_id>/",

--- a/back/games/views.py
+++ b/back/games/views.py
@@ -108,6 +108,21 @@ class GeneralGameLogsListViewSet(viewsets.ModelViewSet):
         return Response(serializer.data)
 
 
+class GeneralGameLogsListMeViewSet(viewsets.ModelViewSet):
+    permission_classes = [IsAuthenticated]
+    queryset = GeneralGameLogs.objects.all()
+    serializer_class: GeneralGameLogsListSerializer = GeneralGameLogsListSerializer
+    http_method_names = ["get"]
+
+    def list(self, request, *args, **kwargs) -> Response:
+        user = request.user
+        queryset = self.queryset.filter(
+            Q(player1=user.user_id) | Q(player2=user.user_id)
+        )
+        serializer = self.serializer_class(queryset, many=True)
+        return Response(serializer.data)
+
+
 class TournamentGameLogsViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
     queryset = TournamentGameLogs.objects.all()
@@ -152,5 +167,22 @@ class TournamentGameLogsListViewSet(viewsets.ModelViewSet):
             queryset = self.queryset.filter(tournament_name=kwargs["name"])
         else:
             raise ValidationError({"detail": "잘못된 요청입니다."})
+        serializer = self.serializer_class(queryset, many=True)
+        return Response(serializer.data)
+
+
+class TournamentGameLogsListMeViewSet(viewsets.ModelViewSet):
+    permission_classes = [IsAuthenticated]
+    queryset = TournamentGameLogs.objects.all()
+    serializer_class: TournamentGameLogsListSerializer = (
+        TournamentGameLogsListSerializer
+    )
+    http_method_names = ["get"]
+
+    def list(self, request, *args, **kwargs) -> Response:
+        user = request.user
+        queryset = self.queryset.filter(
+            Q(player1=user.user_id) | Q(player2=user.user_id)
+        )
         serializer = self.serializer_class(queryset, many=True)
         return Response(serializer.data)


### PR DESCRIPTION
### Summary

- 프론트 요청에 따라 `general_game_logs/me/` 와 `tournament_game_logs/me/` 를 구현했습니다. 


### Describe

#### `game_logs/me/`

- 일반 게임과 토너먼트 게임 관련 자신의 게임 로그를 가져오는 api를 구현했습니다.
- accounts에서 만든 것과 동일하게 viewset을 새로 만들어서 구현했습니다.
- 이와 관련한 간단한 테스트도 추가했습니다.
