### PR TITLE
[Back-55] test disconnect tournament game

### DIFF
--- a/back/accounts/views.py
+++ b/back/accounts/views.py
@@ -190,10 +190,7 @@ class CallbackAPIView(APIView):
         image_address = user_info["image"]["versions"]["large"]
         house = HOUSE[coalition_info[0]["name"]]
         user_instance, created = Users.objects.get_or_create(
-            intra_id=login_id,
-            nickname=login_id,
-            status=0,
-            house=house,
+            intra_id=login_id, defaults={"nickname": login_id, "house": house}
         )
 
         if created:

--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -298,7 +298,9 @@ class TournamentGameWaitConsumer(AsyncWebsocketConsumer):
         tournament_name = data.get("tournament_name")
         if await self.is_exist_game_data_in_db(tournament_name=tournament_name):
             result = ResultType.FAIL.value
-        elif tournament_name is None:
+        elif not tournament_name:
+            result = ResultType.FAIL.value
+        elif len(tournament_name) > MAX_TOURNAMENT_NAME_LENGTH:
             result = ResultType.FAIL.value
         elif tournament_name == NOT_ALLOWED_TOURNAMENT_NAME:
             result = ResultType.FAIL.value

--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -509,8 +509,8 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
             return
 
         # 게임이 비정상 종료 되었을 때
-        if self.round.get_status() != PlayerStatus.END:
-            self.tournament.set_status(TournamentStatus.END)
+        if self.round.get_status() != GameStatus.END:
+            self.tournament.set_status(TournamentStatus.ERROR)
             data = self.round.build_error_json(self.user.intra_id)
             await self.channel_layer.group_send(
                 self.tournament_broadcast,
@@ -547,11 +547,11 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
         if (
             message_type == MessageType.READY.value
             and self.tournament.get_status() == TournamentStatus.READY
-            and self.round_number < 3
+            and self.round_number < int(RoundNumber.FINAL_NUMBER.value)
         ) or (
             message_type == MessageType.READY.value
             and self.tournament.get_status() == TournamentStatus.PLAYING
-            and self.round_number == 3
+            and self.round_number == int(RoundNumber.FINAL_NUMBER.value)
         ):
             self.round.set_round_ready(self.user.intra_id)
             if self.round.is_all_ready():

--- a/back/pong_game/module/GameSetValue.py
+++ b/back/pong_game/module/GameSetValue.py
@@ -13,6 +13,7 @@ MAX_SCORE: int = 5
 PADDLE_BOUNDARY: int = FIELD_WIDTH // 2 - PADDLE_WIDTH // 2
 TOURNAMENT_PLAYER_MAX_CNT: int = 4
 NOT_ALLOWED_TOURNAMENT_NAME: str = "wait"
+MAX_TOURNAMENT_NAME_LENGTH: int = 20
 
 
 class KeyboardInput(Enum):
@@ -30,6 +31,16 @@ class PlayerStatus(Enum):
     PLAYING = "playing"
     SCORE = "score"
     END = "end"
+
+
+class GameStatus(Enum):
+    WAIT = "wait"
+    READY = "ready"
+    ROUND_READY = "round_ready"
+    PLAYING = "playing"
+    SCORE = "score"
+    END = "end"
+    ERROR = "error"
 
 
 class MessageType(Enum):
@@ -54,6 +65,7 @@ class RoundNumber(Enum):
     ROUND_1 = "1"
     ROUND_2 = "2"
     ROUND_3 = "3"
+    FINAL_NUMBER = "3"
 
 
 class TournamentStatus(Enum):
@@ -61,6 +73,7 @@ class TournamentStatus(Enum):
     READY = "ready"
     PLAYING = "playing"
     END = "end"
+    ERROR = "error"
 
 
 class ResultType(Enum):

--- a/back/pong_game/module/GeneralGame.py
+++ b/back/pong_game/module/GeneralGame.py
@@ -10,6 +10,7 @@ from .GameSetValue import (
     MessageType,
     GameTimeType,
     MAX_SCORE,
+    GameStatus,
 )
 
 
@@ -20,7 +21,7 @@ class GeneralGame:
         self.player2: Player = player2
         self.score1: int = 0
         self.score2: int = 0
-        self.status: PlayerStatus = PlayerStatus.WAIT
+        self.status: GameStatus = GameStatus.WAIT
         self.start_time: datetime | None = None
         self.end_time: datetime | None = None
 
@@ -128,7 +129,7 @@ class GeneralGame:
         )
 
     def build_error_json(self, intra_id: str) -> json:
-        self.status = PlayerStatus.END
+        self.status = GameStatus.END
         return json.dumps(
             {
                 "message_type": MessageType.ERROR.value,
@@ -145,11 +146,11 @@ class GeneralGame:
         if self._is_past_paddle1():
             self.score2 += 1
             self._reset_position()
-            self.status = PlayerStatus.SCORE
+            self.status = GameStatus.SCORE
         elif self._is_past_paddle2():
             self.score1 += 1
             self._reset_position()
-            self.status = PlayerStatus.SCORE
+            self.status = GameStatus.SCORE
         elif self.ball.is_side_collision():
             self.ball.speed_x *= -1
         elif self._is_paddle1_collision():
@@ -164,7 +165,7 @@ class GeneralGame:
             return self.player2, 2
         return None
 
-    def get_status(self) -> PlayerStatus:
+    def get_status(self) -> GameStatus:
         return self.status
 
     def get_score(self) -> tuple:
@@ -221,5 +222,5 @@ class GeneralGame:
         elif number == "player2":
             self.player2.set_status(PlayerStatus.READY)
 
-    def set_status(self, status: PlayerStatus) -> None:
+    def set_status(self, status: GameStatus) -> None:
         self.status = status

--- a/back/pong_game/module/Tournament.py
+++ b/back/pong_game/module/Tournament.py
@@ -8,6 +8,8 @@ from .GameSetValue import (
     PlayerStatus,
     TournamentGroupName,
     RoundNumber,
+    GameStatus,
+    GameTimeType,
 )
 from .Player import Player
 from .Round import Round
@@ -127,6 +129,11 @@ class Tournament:
 
         return True
 
+    def is_all_round_ready(self):
+        if self.round_list[0].is_all_ready() and self.round_list[1].is_all_ready():
+            return True
+        return False
+
     def get_status(self) -> TournamentStatus:
         return self.status
 
@@ -159,3 +166,19 @@ class Tournament:
             return False
         self.player_list[idx].set_status(PlayerStatus.READY)
         return True
+
+    def set_round_status(self, status: GameStatus, is_final: bool) -> None:
+        if is_final:
+            self.round_list[int(RoundNumber.FINAL_NUMBER.value) - 1].set_status(status)
+        else:
+            for i in range(int(RoundNumber.FINAL_NUMBER.value) - 1):
+                self.round_list[i].set_status(status)
+
+    def set_round_game_time(self, time_type: GameTimeType, is_final: bool) -> None:
+        if is_final:
+            self.round_list[int(RoundNumber.FINAL_NUMBER.value) - 1].set_game_time(
+                time_type=time_type.value
+            )
+        else:
+            for i in range(int(RoundNumber.FINAL_NUMBER.value) - 1):
+                self.round_list[i].set_game_time(time_type=time_type.value)

--- a/back/pong_game/tests.py
+++ b/back/pong_game/tests.py
@@ -1294,6 +1294,7 @@ class TournamentGameRoundConsumerTests(TestCase):
                 "2p": self.room_1_user3_id,
             },
         ]
+
         await self.check_recieved_ready_messgae_valid(
             users_ready_info=users_ready_info_test_tournament1,
             communicators=self.test_tournament1_communicators,
@@ -1308,23 +1309,22 @@ class TournamentGameRoundConsumerTests(TestCase):
             await communicator.disconnect()
 
         self.test_tournament1_communicators = []
+        round_list = [1, 1, 2, 2]
         for idx, (ready_info, user_info) in enumerate(
-            zip(users_ready_info_test_tournament1, users_info_test_tournament1), start=0
+            zip(users_ready_info_test_tournament1, users_info_test_tournament1),
+            start=0,
         ):
-            # if idx == 0 or idx == 3:
-            #     round = 1
-            # else:
-            #     round = 2
             user = await self.get_user(intra_id=user_info["intra_id"])
             communicator = await self.connect_and_send_ready_data(
                 tournament_name=self.room_1_name,
                 user=user,
-                round=idx // 2 + 1,
+                round=round_list[idx],
                 ready_data=ready_info,
             )
             self.test_tournament1_communicators.append(communicator)
 
         # start 메시지 잘 받는지 확인
+
         start_reponse = await self.test_tournament1_communicators[0].receive_from()
         start_reponse_dict = json.loads(start_reponse)
         self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
@@ -1510,3 +1510,698 @@ class TournamentGameRoundConsumerTests(TestCase):
 
         self.assertEqual(room_1_user3.win_count, 2)
         self.assertEqual(room_1_user3.lose_count, 0)
+
+    @patch("pong_game.module.GameSetValue.BALL_SPEED_Z", 300)
+    async def test_round_logic_test1221(self):
+        """
+        정상적인 로직으로 진행했을때 결승전까지 잘 마무리 되는지 테스트
+        """
+        users_info_test_tournament1 = [
+            {
+                "intra_id": self.room_1_owner_id,
+                "expected_player_number": PlayerNumber.PLAYER_1,
+            },
+            {
+                "intra_id": self.room_1_user1_id,
+                "expected_player_number": PlayerNumber.PLAYER_2,
+            },
+            {
+                "intra_id": self.room_1_user2_id,
+                "expected_player_number": PlayerNumber.PLAYER_3,
+            },
+            {
+                "intra_id": self.room_1_user3_id,
+                "expected_player_number": PlayerNumber.PLAYER_4,
+            },
+        ]
+        # 1 2 2 1
+        users_info_test_tournament1221 = [
+            {
+                "intra_id": self.room_1_owner_id,
+                "expected_player_number": PlayerNumber.PLAYER_1,
+            },
+            {
+                "intra_id": self.room_1_user2_id,
+                "expected_player_number": PlayerNumber.PLAYER_3,
+            },
+            {
+                "intra_id": self.room_1_user3_id,
+                "expected_player_number": PlayerNumber.PLAYER_4,
+            },
+            {
+                "intra_id": self.room_1_user1_id,
+                "expected_player_number": PlayerNumber.PLAYER_2,
+            },
+        ]
+
+        self.test_tournament1_communicators = await self.perform_test_sequence(
+            self.room_1_name, users_info_test_tournament1
+        )
+
+        users_ready_info_test_tournament1 = [
+            {
+                "message_type": MessageType.READY.value,
+                "round": "1",
+                "1p": self.room_1_owner_id,
+                "2p": self.room_1_user1_id,
+            },
+            {
+                "message_type": MessageType.READY.value,
+                "round": "1",
+                "1p": self.room_1_owner_id,
+                "2p": self.room_1_user1_id,
+            },
+            {
+                "message_type": MessageType.READY.value,
+                "round": "2",
+                "1p": self.room_1_user2_id,
+                "2p": self.room_1_user3_id,
+            },
+            {
+                "message_type": MessageType.READY.value,
+                "round": "2",
+                "1p": self.room_1_user2_id,
+                "2p": self.room_1_user3_id,
+            },
+        ]
+        # 1221
+        users_ready_info_test_tournament1221 = [
+            {
+                "message_type": MessageType.READY.value,
+                "round": "1",
+                "1p": self.room_1_owner_id,
+                "2p": self.room_1_user1_id,
+            },
+            {
+                "message_type": MessageType.READY.value,
+                "round": "2",
+                "1p": self.room_1_user2_id,
+                "2p": self.room_1_user3_id,
+            },
+            {
+                "message_type": MessageType.READY.value,
+                "round": "2",
+                "1p": self.room_1_user2_id,
+                "2p": self.room_1_user3_id,
+            },
+            {
+                "message_type": MessageType.READY.value,
+                "round": "1",
+                "1p": self.room_1_owner_id,
+                "2p": self.room_1_user1_id,
+            },
+        ]
+        await self.check_recieved_ready_messgae_valid(
+            users_ready_info=users_ready_info_test_tournament1,
+            communicators=self.test_tournament1_communicators,
+        )
+
+        await self.discard_all_message(
+            communicators=self.test_tournament1_communicators
+        )
+
+        # 접속 다 끊기
+        for communicator in self.test_tournament1_communicators:
+            await communicator.disconnect()
+
+        self.test_tournament1_communicators = []
+        round_list = [1, 2, 2, 1]
+        for idx, (ready_info, user_info) in enumerate(
+            zip(users_ready_info_test_tournament1221, users_info_test_tournament1221),
+            start=0,
+        ):
+            user = await self.get_user(intra_id=user_info["intra_id"])
+            communicator = await self.connect_and_send_ready_data(
+                tournament_name=self.room_1_name,
+                user=user,
+                round=round_list[idx],
+                ready_data=ready_info,
+            )
+            self.test_tournament1_communicators.append(communicator)
+
+        # start 메시지 잘 받는지 확인
+        start_reponse = await self.test_tournament1_communicators[0].receive_from()
+        start_reponse_dict = json.loads(start_reponse)
+        self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
+        self.assertEqual(start_reponse_dict["round"], "1")
+        start_reponse = await self.test_tournament1_communicators[1].receive_from()
+        start_reponse_dict = json.loads(start_reponse)
+        self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
+        self.assertEqual(start_reponse_dict["round"], "2")
+        start_reponse = await self.test_tournament1_communicators[2].receive_from()
+        start_reponse_dict = json.loads(start_reponse)
+        self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
+        self.assertEqual(start_reponse_dict["round"], "2")
+        start_reponse = await self.test_tournament1_communicators[3].receive_from()
+        start_reponse_dict = json.loads(start_reponse)
+        self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
+        self.assertEqual(start_reponse_dict["round"], "1")
+
+        await self.test_tournament1_communicators[0].send_to(
+            text_data=json.dumps(
+                {"message_type": "playing", "number": "player1", "input": "left_press"}
+            )
+        )
+
+        await self.test_tournament1_communicators[2].send_to(
+            text_data=json.dumps(
+                {"message_type": "playing", "number": "player1", "input": "left_press"}
+            )
+        )
+
+        while True:
+            user1_response = await self.test_tournament1_communicators[0].receive_from()
+            user1_dict = json.loads(user1_response)
+            if (
+                user1_dict["message_type"] == "end"
+                or user1_dict["message_type"] == "stay"
+            ):
+                break
+
+        while True:
+            user2_response = await self.test_tournament1_communicators[1].receive_from()
+            user2_dict = json.loads(user2_response)
+            if (
+                user2_dict["message_type"] == "end"
+                or user2_dict["message_type"] == "stay"
+            ):
+                break
+
+        while True:
+            user3_response = await self.test_tournament1_communicators[2].receive_from()
+            user3_dict = json.loads(user3_response)
+            if (
+                user3_dict["message_type"] == "end"
+                or user3_dict["message_type"] == "stay"
+            ):
+                break
+
+        while True:
+            user4_response = await self.test_tournament1_communicators[3].receive_from()
+            user4_dict = json.loads(user4_response)
+            if (
+                user4_dict["message_type"] == "end"
+                or user4_dict["message_type"] == "stay"
+            ):
+                break
+
+        await self.discard_all_message(self.test_tournament1_communicators)
+
+        await self.test_tournament1_communicators[1].send_to(
+            json.dumps(
+                {
+                    "message_type": "stay",
+                    "round": "1",
+                    "winner": "room_1_user1",
+                    "loser": "room_1_owner",
+                }
+            )
+        )
+
+        await self.test_tournament1_communicators[3].send_to(
+            json.dumps(
+                {
+                    "message_type": "stay",
+                    "round": "2",
+                    "winner": "room_1_user3",
+                    "loser": "room_1_user2",
+                }
+            )
+        )
+
+        await self.discard_all_message(self.test_tournament1_communicators)
+
+        # 연결 끊기
+        for communicator in self.test_tournament1_communicators:
+            await communicator.disconnect()
+
+        self.test_tournament1_communicators = []
+        self.test_tournament1_communicators.append(
+            await self.connect_and_send_ready_data(
+                tournament_name=self.room_1_name,
+                user=await self.get_user(intra_id=self.room_1_user1_id),
+                round=3,
+                ready_data={
+                    "message_type": MessageType.READY.value,
+                    "round": "3",
+                    "1p": self.room_1_user1_id,
+                    "2p": self.room_1_user3_id,
+                },
+            )
+        )
+
+        self.test_tournament1_communicators.append(
+            await self.connect_and_send_ready_data(
+                tournament_name=self.room_1_name,
+                user=await self.get_user(intra_id=self.room_1_user3_id),
+                round=3,
+                ready_data={
+                    "message_type": MessageType.READY.value,
+                    "round": "3",
+                    "1p": self.room_1_user1_id,
+                    "2p": self.room_1_user3_id,
+                },
+            )
+        )
+
+        await self.test_tournament1_communicators[0].receive_from()
+        await self.test_tournament1_communicators[1].receive_from()
+
+        await self.test_tournament1_communicators[0].send_to(
+            text_data=json.dumps(
+                {"message_type": "playing", "number": "player1", "input": "left_press"}
+            )
+        )
+
+        while True:
+            user2_response = await self.test_tournament1_communicators[0].receive_from()
+            user2_dict = json.loads(user2_response)
+            if (
+                user2_dict["message_type"] == "end"
+                or user2_dict["message_type"] == "stay"
+            ):
+                break
+
+        while True:
+            user4_response = await self.test_tournament1_communicators[1].receive_from()
+            user4_dict = json.loads(user4_response)
+            if (
+                user4_dict["message_type"] == "end"
+                or user4_dict["message_type"] == "stay"
+            ):
+                break
+
+        await self.discard_all_message(self.test_tournament1_communicators)
+        await self.test_tournament1_communicators[0].send_to(
+            json.dumps(
+                {
+                    "message_type": "stay",
+                    "round": "3",
+                    "winner": "room_1_user3",
+                    "loser": "room_1_user1",
+                }
+            )
+        )
+
+        # tournament db에 잘 저장 됐는지 확인하는 테스트
+        await self.wait_for_tournament_data(tournamnet_name=self.room_1_name, round=1)
+        await self.wait_for_tournament_data(tournamnet_name=self.room_1_name, round=2)
+        await self.wait_for_tournament_data(tournamnet_name=self.room_1_name, round=3)
+        await self.discard_all_message(self.test_tournament1_communicators)
+
+        # user db에 잘 저장 됐는지 확인하는 테스트
+        room_1_owner = await self.get_user(self.room_1_owner_id)
+        room_1_user1 = await self.get_user(self.room_1_user1_id)
+        room_1_user2 = await self.get_user(self.room_1_user2_id)
+        room_1_user3 = await self.get_user(self.room_1_user3_id)
+        self.assertEqual(room_1_owner.win_count, 0)
+        self.assertEqual(room_1_owner.lose_count, 1)
+
+        self.assertEqual(room_1_user1.win_count, 1)
+        self.assertEqual(room_1_user1.lose_count, 1)
+
+        self.assertEqual(room_1_user2.win_count, 0)
+        self.assertEqual(room_1_user2.lose_count, 1)
+
+        self.assertEqual(room_1_user3.win_count, 2)
+        self.assertEqual(room_1_user3.lose_count, 0)
+
+    @patch("pong_game.module.GameSetValue.BALL_SPEED_Z", 300)
+    async def test_disconnect(self):
+        """
+        1라운드 도중에 disconnect 됐을때
+        """
+        users_info_test_tournament1 = [
+            {
+                "intra_id": self.room_1_owner_id,
+                "expected_player_number": PlayerNumber.PLAYER_1,
+            },
+            {
+                "intra_id": self.room_1_user1_id,
+                "expected_player_number": PlayerNumber.PLAYER_2,
+            },
+            {
+                "intra_id": self.room_1_user2_id,
+                "expected_player_number": PlayerNumber.PLAYER_3,
+            },
+            {
+                "intra_id": self.room_1_user3_id,
+                "expected_player_number": PlayerNumber.PLAYER_4,
+            },
+        ]
+
+        self.test_tournament1_communicators = await self.perform_test_sequence(
+            self.room_1_name, users_info_test_tournament1
+        )
+
+        users_ready_info_test_tournament1 = [
+            {
+                "message_type": MessageType.READY.value,
+                "round": "1",
+                "1p": self.room_1_owner_id,
+                "2p": self.room_1_user1_id,
+            },
+            {
+                "message_type": MessageType.READY.value,
+                "round": "1",
+                "1p": self.room_1_owner_id,
+                "2p": self.room_1_user1_id,
+            },
+            {
+                "message_type": MessageType.READY.value,
+                "round": "2",
+                "1p": self.room_1_user2_id,
+                "2p": self.room_1_user3_id,
+            },
+            {
+                "message_type": MessageType.READY.value,
+                "round": "2",
+                "1p": self.room_1_user2_id,
+                "2p": self.room_1_user3_id,
+            },
+        ]
+
+        await self.check_recieved_ready_messgae_valid(
+            users_ready_info=users_ready_info_test_tournament1,
+            communicators=self.test_tournament1_communicators,
+        )
+
+        await self.discard_all_message(
+            communicators=self.test_tournament1_communicators
+        )
+
+        # 접속 다 끊기
+        for communicator in self.test_tournament1_communicators:
+            await communicator.disconnect()
+
+        self.test_tournament1_communicators = []
+        round_list = [1, 1, 2, 2]
+        for idx, (ready_info, user_info) in enumerate(
+            zip(users_ready_info_test_tournament1, users_info_test_tournament1),
+            start=0,
+        ):
+            user = await self.get_user(intra_id=user_info["intra_id"])
+            communicator = await self.connect_and_send_ready_data(
+                tournament_name=self.room_1_name,
+                user=user,
+                round=round_list[idx],
+                ready_data=ready_info,
+            )
+            self.test_tournament1_communicators.append(communicator)
+
+        # start 메시지 잘 받는지 확인
+
+        start_reponse = await self.test_tournament1_communicators[0].receive_from()
+        start_reponse_dict = json.loads(start_reponse)
+        self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
+        self.assertEqual(start_reponse_dict["round"], "1")
+        start_reponse = await self.test_tournament1_communicators[1].receive_from()
+        start_reponse_dict = json.loads(start_reponse)
+        self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
+        self.assertEqual(start_reponse_dict["round"], "1")
+        start_reponse = await self.test_tournament1_communicators[2].receive_from()
+        start_reponse_dict = json.loads(start_reponse)
+        self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
+        self.assertEqual(start_reponse_dict["round"], "2")
+        start_reponse = await self.test_tournament1_communicators[3].receive_from()
+        start_reponse_dict = json.loads(start_reponse)
+        self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
+        self.assertEqual(start_reponse_dict["round"], "2")
+
+        await self.test_tournament1_communicators[0].send_to(
+            text_data=json.dumps(
+                {"message_type": "playing", "number": "player1", "input": "left_press"}
+            )
+        )
+
+        await self.test_tournament1_communicators[2].send_to(
+            text_data=json.dumps(
+                {"message_type": "playing", "number": "player1", "input": "left_press"}
+            )
+        )
+
+        # 1점내고 게임 나가기
+        while True:
+            user1_response = await self.test_tournament1_communicators[0].receive_from()
+            user1_dict = json.loads(user1_response)
+            if user1_dict["message_type"] == "score":
+                await self.test_tournament1_communicators[0].disconnect()
+                break
+
+        count = 0
+        for idx, communicator in enumerate(self.test_tournament1_communicators):
+            while await communicator.receive_nothing() is False:
+                message = await communicator.receive_from()
+                message_dict = json.loads(message)
+                print(message_dict)
+                if message_dict["message_type"] == "error":
+                    count += 1
+                if (
+                    message_dict["message_type"] == "stay"
+                    or message_dict["message_type"] == "end"
+                ):
+                    self.assertTrue(False)
+
+        self.assertEqual(count, 3)
+
+    @patch("pong_game.module.GameSetValue.BALL_SPEED_Z", 300)
+    async def test_disconnect2(self):
+        """
+        마지막 라운드일때 나가기
+        """
+        users_info_test_tournament1 = [
+            {
+                "intra_id": self.room_1_owner_id,
+                "expected_player_number": PlayerNumber.PLAYER_1,
+            },
+            {
+                "intra_id": self.room_1_user1_id,
+                "expected_player_number": PlayerNumber.PLAYER_2,
+            },
+            {
+                "intra_id": self.room_1_user2_id,
+                "expected_player_number": PlayerNumber.PLAYER_3,
+            },
+            {
+                "intra_id": self.room_1_user3_id,
+                "expected_player_number": PlayerNumber.PLAYER_4,
+            },
+        ]
+
+        self.test_tournament1_communicators = await self.perform_test_sequence(
+            self.room_1_name, users_info_test_tournament1
+        )
+
+        users_ready_info_test_tournament1 = [
+            {
+                "message_type": MessageType.READY.value,
+                "round": "1",
+                "1p": self.room_1_owner_id,
+                "2p": self.room_1_user1_id,
+            },
+            {
+                "message_type": MessageType.READY.value,
+                "round": "1",
+                "1p": self.room_1_owner_id,
+                "2p": self.room_1_user1_id,
+            },
+            {
+                "message_type": MessageType.READY.value,
+                "round": "2",
+                "1p": self.room_1_user2_id,
+                "2p": self.room_1_user3_id,
+            },
+            {
+                "message_type": MessageType.READY.value,
+                "round": "2",
+                "1p": self.room_1_user2_id,
+                "2p": self.room_1_user3_id,
+            },
+        ]
+
+        await self.check_recieved_ready_messgae_valid(
+            users_ready_info=users_ready_info_test_tournament1,
+            communicators=self.test_tournament1_communicators,
+        )
+
+        await self.discard_all_message(
+            communicators=self.test_tournament1_communicators
+        )
+
+        # 접속 다 끊기
+        for communicator in self.test_tournament1_communicators:
+            await communicator.disconnect()
+
+        self.test_tournament1_communicators = []
+        round_list = [1, 1, 2, 2]
+        for idx, (ready_info, user_info) in enumerate(
+            zip(users_ready_info_test_tournament1, users_info_test_tournament1),
+            start=0,
+        ):
+            user = await self.get_user(intra_id=user_info["intra_id"])
+            communicator = await self.connect_and_send_ready_data(
+                tournament_name=self.room_1_name,
+                user=user,
+                round=round_list[idx],
+                ready_data=ready_info,
+            )
+            self.test_tournament1_communicators.append(communicator)
+
+        # start 메시지 잘 받는지 확인
+
+        start_reponse = await self.test_tournament1_communicators[0].receive_from()
+        start_reponse_dict = json.loads(start_reponse)
+        self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
+        self.assertEqual(start_reponse_dict["round"], "1")
+        start_reponse = await self.test_tournament1_communicators[1].receive_from()
+        start_reponse_dict = json.loads(start_reponse)
+        self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
+        self.assertEqual(start_reponse_dict["round"], "1")
+        start_reponse = await self.test_tournament1_communicators[2].receive_from()
+        start_reponse_dict = json.loads(start_reponse)
+        self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
+        self.assertEqual(start_reponse_dict["round"], "2")
+        start_reponse = await self.test_tournament1_communicators[3].receive_from()
+        start_reponse_dict = json.loads(start_reponse)
+        self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
+        self.assertEqual(start_reponse_dict["round"], "2")
+
+        await self.test_tournament1_communicators[0].send_to(
+            text_data=json.dumps(
+                {"message_type": "playing", "number": "player1", "input": "left_press"}
+            )
+        )
+
+        await self.test_tournament1_communicators[2].send_to(
+            text_data=json.dumps(
+                {"message_type": "playing", "number": "player1", "input": "left_press"}
+            )
+        )
+
+        while True:
+            user1_response = await self.test_tournament1_communicators[0].receive_from()
+            user1_dict = json.loads(user1_response)
+            if (
+                user1_dict["message_type"] == "end"
+                or user1_dict["message_type"] == "stay"
+            ):
+                break
+
+        while True:
+            user2_response = await self.test_tournament1_communicators[1].receive_from()
+            user2_dict = json.loads(user2_response)
+            if (
+                user2_dict["message_type"] == "end"
+                or user2_dict["message_type"] == "stay"
+            ):
+                break
+
+        while True:
+            user3_response = await self.test_tournament1_communicators[2].receive_from()
+            user3_dict = json.loads(user3_response)
+            if (
+                user3_dict["message_type"] == "end"
+                or user3_dict["message_type"] == "stay"
+            ):
+                break
+
+        while True:
+            user4_response = await self.test_tournament1_communicators[3].receive_from()
+            user4_dict = json.loads(user4_response)
+            if (
+                user4_dict["message_type"] == "end"
+                or user4_dict["message_type"] == "stay"
+            ):
+                break
+
+        await self.discard_all_message(self.test_tournament1_communicators)
+
+        await self.test_tournament1_communicators[1].send_to(
+            json.dumps(
+                {
+                    "message_type": "stay",
+                    "round": "1",
+                    "winner": "room_1_user1",
+                    "loser": "room_1_owner",
+                }
+            )
+        )
+
+        await self.test_tournament1_communicators[3].send_to(
+            json.dumps(
+                {
+                    "message_type": "stay",
+                    "round": "2",
+                    "winner": "room_1_user3",
+                    "loser": "room_1_user2",
+                }
+            )
+        )
+
+        await self.discard_all_message(self.test_tournament1_communicators)
+
+        # 연결 끊기
+        for communicator in self.test_tournament1_communicators:
+            await communicator.disconnect()
+
+        self.test_tournament1_communicators = []
+        self.test_tournament1_communicators.append(
+            await self.connect_and_send_ready_data(
+                tournament_name=self.room_1_name,
+                user=await self.get_user(intra_id=self.room_1_user1_id),
+                round=3,
+                ready_data={
+                    "message_type": MessageType.READY.value,
+                    "round": "3",
+                    "1p": self.room_1_user1_id,
+                    "2p": self.room_1_user3_id,
+                },
+            )
+        )
+
+        self.test_tournament1_communicators.append(
+            await self.connect_and_send_ready_data(
+                tournament_name=self.room_1_name,
+                user=await self.get_user(intra_id=self.room_1_user3_id),
+                round=3,
+                ready_data={
+                    "message_type": MessageType.READY.value,
+                    "round": "3",
+                    "1p": self.room_1_user1_id,
+                    "2p": self.room_1_user3_id,
+                },
+            )
+        )
+
+        await self.test_tournament1_communicators[0].receive_from()
+        await self.test_tournament1_communicators[1].receive_from()
+
+        await self.test_tournament1_communicators[0].send_to(
+            text_data=json.dumps(
+                {"message_type": "playing", "number": "player1", "input": "left_press"}
+            )
+        )
+
+        # 1점 내고 나가기
+        while True:
+            user2_response = await self.test_tournament1_communicators[0].receive_from()
+            user2_dict = json.loads(user2_response)
+            if user2_dict["message_type"] == "score":
+                await self.test_tournament1_communicators[1].disconnect()
+                break
+
+        count = 0
+        for idx, communicator in enumerate(self.test_tournament1_communicators):
+            while await communicator.receive_nothing() is False:
+                message = await communicator.receive_from()
+                message_dict = json.loads(message)
+                print(message_dict)
+                if message_dict["message_type"] == "error":
+                    count += 1
+                if (
+                    message_dict["message_type"] == "stay"
+                    or message_dict["message_type"] == "end"
+                ):
+                    self.assertTrue(False)
+
+        self.assertEqual(count, 1)

--- a/back/pong_game/tests.py
+++ b/back/pong_game/tests.py
@@ -1953,7 +1953,6 @@ class TournamentGameRoundConsumerTests(TestCase):
             while await communicator.receive_nothing() is False:
                 message = await communicator.receive_from()
                 message_dict = json.loads(message)
-                print(message_dict)
                 if message_dict["message_type"] == "error":
                     count += 1
                 if (
@@ -2195,7 +2194,6 @@ class TournamentGameRoundConsumerTests(TestCase):
             while await communicator.receive_nothing() is False:
                 message = await communicator.receive_from()
                 message_dict = json.loads(message)
-                print(message_dict)
                 if message_dict["message_type"] == "error":
                     count += 1
                 if (

--- a/makefile
+++ b/makefile
@@ -13,7 +13,7 @@ test:
 	cd ./back/ && python3 manage.py test games --settings=back.test_settings
 	cd ./back/ && python3 manage.py test accounts --settings=back.test_settings
 	cd ./back/ && python3 manage.py test pong_game.tests.GeneralGameConsumerTests.test_save_game_data_to_db --settings=back.test_settings
-	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameRoundConsumerTests --settings=back.test_settings
+	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameRoundConsumerTests.test_disconnect2  --settings=back.test_settings
 #	cd ./back/ && python3 manage.py test pong_game.tests.GeneralGameConsumerTests.test_save_game_data_to_db --settings=back.test_settings
 #	cd ./back/ && python3 manage.py test  --settings=back.test_settings
 #	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameConsumerTests.test_disconnect_test2 --settings=back.test_settings


### PR DESCRIPTION
### Summary
- `get_or_create()` 매개변수 수정했습니다.
- `PlayerStatus`를 `GameStatus`로 변경했습니다.
- 토너먼트 이름 글자 수 확인하는 로직 추가했습니다.
- `TournamentGameRoundConsumer`에서 플레이어 연결 순서와 관계없이 진행되도록 수정했습니다.
- 비정상 `disconnect`시 `TournamentStatus.ERROR`로 변경하는 로직 추가했습니다.
- 관련된 테스트 추가했습니다.
### Describe
#### `get_or_create()` 매개변수 수정했습니다.
- `Oauth`로 로그인한 후 다른 브라우저에서 같은 아이디로 로그인 했을 때 `IntegrityError`가 발생했습니다.
- `get_or_create`()의 `kwargs`인자는 검색에 `defaults`인자는 생성 시 사용되므로, 이를 분리하여 명확하게 구분하였습니다.
#### `PlayerStatus`를 `GameStatus`로 변경했습니다.
- 게임의 상태 관리를 위해 `PlayerStatus` 대신 `GameStatus`를 도입하여, 상태 관리의 명확성과 유지 보수성을 개선했습니다.
#### 토너먼트 이름 글자수 확인하는 로직 추가했습니다.
- 게임 모델 규정에 따라 토너먼트 이름은 최대 20글자로 제한됩니다.
- 사용자가 규정을 초과하는 이름을 입력할 경우를 방지하기 위해, 이름 길이를 검증하는 로직을 추가했습니다.
####  `TournamentGameRoundConsumer`에서 플레이어 connect 순서 상관없이 진행되도록 수정했습니다.
- 기존 로직에서는 플레이어의 연결 순서에 따라 게임 진행에 오류가 발생할 수 있었습니다.(1221 문제)
- 모든 라운드의 플레이어가 준비 상태일 때만 게임이 시작되도록 로직을 개선했습니다.
##### 1221 문제
- 라운드 consumer에서 1라운드 1p(1-1), 1-2, 2-1, 2-2 플레이어가 있을 때 1-1, 1-2, 2-1, 2-2 순서대로 connect 하는 것을 1, 1, 2, 2라고 해보겠습니다.
- 이때 `1122`로 `connect`할때는 문제가 안 되지만 `1221`로 `connect` 할 때 문제가 발생했습니다.
##### 원인
- 기존의 코드에서 `if self.round.is_all_ready()`는 round 내부의 1p, 2p가 `round_ready`인지 확인했습니다.
- 즉  `1221`에서 122일 때 2라운드에 p, 2p는 `round_ready` 상태이므로 if 문을 만족하고 그 밑에 있는 `self.tournament.set_status(TournamentStatus.PLAYING)`가 실행됩니다.
- 1221에서 마지막 1이 connect 되면 connect 함수의 `self.tournament.get_status() == TournamentStatus.READY`에서 false가 돼서 연결이 안 됩니다.
##### 해결
- `tournament.is_all_round_ready`를 만들어서 토너먼트 내부의 라운드 플레이어들이 모두 round_ready 상태일 때 `self.tournament.set_status(TournamentStatus.PLAYING)`가 실행되도록 수정했습니다.
#### 비정상 `disconnect`시 `TournamentStatus.ERROR`로 변경하는 로직 추가했습니다.
- 이전에는 모든 `disconnect`를 `TournamentStatus.END`로 처리했으나, 비정상적인 상황에서도 게임이 종료되는 문제가 있었습니다.
- 비정상 `disconnect` 시 `TournamentStatus.ERROR`로 변경했습니다.
- `send_game_messages_loop`에서 `TournamentStatus.ERROR`인 경우 멈추도록 조건을 추가했습니다.
#### 관련된 테스트 추가했습니다.
- `1221` 관련, `disconnect` 관련 테스트 추가했습니다.
### TODO
- 실제 통합레포에서 테스트가 더 필요합니다.
