### PR TITLE
[Back-63] turn off debug mode

### DIFF
--- a/back/back/settings.py
+++ b/back/back/settings.py
@@ -28,15 +28,11 @@ load_dotenv()
 SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
-ALLOWED_HOSTS = ["*"]
-
-# frontend 요구 사항
-CSRF_TRUSTED_ORIGINS = [f"https://{os.environ.get('BASE_IP')}/"]
+ALLOWED_HOSTS = [os.environ.get("BASE_IP")]
 
 # Application definition
-
 INSTALLED_APPS = [
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -68,35 +64,6 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
-
-# 허용할 메소드
-CORS_ALLOW_METHODS = [
-    "DELETE",
-    "GET",
-    "OPTIONS",
-    "PATCH",
-    "POST",
-    "PUT",
-]
-
-# 허용할 헤더
-CORS_ALLOW_HEADERS = [
-    "accept",
-    "accept-encoding",
-    "authorization",
-    "content-type",
-    "dnt",
-    "origin",
-    "user-agent",
-    "x-csrftoken",
-    "x-requested-with",
-]
-
-# CORS 전체 허용
-CORS_ORIGIN_ALLOW_ALL = True
-
-# 쿠키가 cross-site HTTP 요청에 포함될 수 있도록 허용
-CORS_ALLOW_CREDENTIALS = True
 
 ROOT_URLCONF = "back.urls"
 

--- a/back/back/urls.py
+++ b/back/back/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path, include, re_path
 from django.conf import settings
-from django.conf.urls.static import static
+from django.views.static import serve
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from rest_framework.permissions import AllowAny
@@ -37,4 +37,7 @@ urlpatterns = [
         schema_view_v1.with_ui("redoc", cache_timeout=0),
         name="schema-redoc",
     ),
-] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    re_path(
+        r"^api/v1/media/(?P<path>.*)$", serve, {"document_root": settings.MEDIA_ROOT}
+    ),
+]


### PR DESCRIPTION
### Summary

- `DEBUG` 모드를 껐습니다.
- `CORS` 관련 설정을 제거했습니다.
- `media` 폴더 url을 재설정했습니다.


### Describe

#### `DEBUG` 모드

- production 준비가 거의 마무리 되어가기에 `DEBUG` 모드를 종료했습니다.
- 또한 `ALLOWED_HOSTS` 역시 현재 `BASE_URL` 만 허용하도록 수정했습니다.

#### `CORS` 관련 설정 제거

- nginx를 middleware로 front와 back이 통합되었기 때문에 CORS 설정을 제거하였습니다.

#### `media` 폴더 경로 재설정

- `DEBUG` 모드를 종료하면서 기존의 `STATIC` 은 경로로 사용할 수 없습니다.
- 그렇기에 `re_path()` 함수로 경로를 재설정 했습니다.
- `static`은 현재 없기 때문에 따로 재설정하지 않았습니다.


### TODO

- 제가 확인했지만 프론트 개발자들이 통합 레포지토리에서 잘 동작하는지 확인해봐야 합니다.
