### PR TITLE
[Back-64] fixed game error

### DIFF
--- a/back/accounts/models.py
+++ b/back/accounts/models.py
@@ -6,10 +6,14 @@ from django.db import models
 
 
 class UserManager(BaseUserManager):
-    def create_user(self, intra_id, **extra_fields):
+    def create_user(self, intra_id, nickname=None, **extra_fields):
         if not intra_id:
             raise ValueError("The Intra ID must be set")
-        user: Users = self.model(intra_id=intra_id, nickname=intra_id, **extra_fields)
+        user: Users = self.model(
+            intra_id=intra_id,
+            nickname=nickname if nickname else intra_id,
+            **extra_fields
+        )
         user.save(using=self._db)
         user.set_unusable_password()
         return user

--- a/back/back/test_settings.py
+++ b/back/back/test_settings.py
@@ -7,6 +7,8 @@ DATABASES = {
     }
 }
 
+ALLOWED_HOSTS = ["*"]
+
 CHANNEL_LAYERS = {
     "default": {
         "BACKEND": "channels_redis.core.RedisChannelLayer",

--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -563,6 +563,9 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
 
                 if self.tournament.is_all_round_ready():
                     if self.round_number != int(RoundNumber.FINAL_NUMBER.value):
+                        player1_intra_id, player2_intra_id = self.tournament.get_round(
+                            1
+                        ).get_intra_ids()
                         await self.channel_layer.group_send(
                             hashlib.md5(
                                 (self.tournament_name + "_" + "1").encode("utf-8")
@@ -573,10 +576,15 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
                                     {
                                         "message_type": MessageType.START.value,
                                         "round": "1",
+                                        "1p": player1_intra_id,
+                                        "2p": player2_intra_id,
                                     }
                                 ),
                             },
                         )
+                        player3_intra_id, player4_intra_id = self.tournament.get_round(
+                            2
+                        ).get_intra_ids()
                         await self.channel_layer.group_send(
                             hashlib.md5(
                                 (self.tournament_name + "_" + "2").encode("utf-8")
@@ -587,6 +595,8 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
                                     {
                                         "message_type": MessageType.START.value,
                                         "round": "2",
+                                        "1p": player3_intra_id,
+                                        "2p": player4_intra_id,
                                     }
                                 ),
                             },
@@ -600,6 +610,9 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
                         self.tournament.set_status(status=TournamentStatus.PLAYING)
 
                     else:
+                        player1_intra_id, player2_intra_id = self.tournament.get_round(
+                            3
+                        ).get_intra_ids()
                         await self.channel_layer.group_send(
                             hashlib.md5(
                                 (self.tournament_name + "_" + "3").encode("utf-8")
@@ -610,6 +623,8 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
                                     {
                                         "message_type": MessageType.START.value,
                                         "round": "3",
+                                        "1p": player1_intra_id,
+                                        "2p": player2_intra_id,
                                     }
                                 ),
                             },

--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -56,7 +56,7 @@ class LoginConsumer(AsyncWebsocketConsumer):
 
 
 class GeneralGameWaitConsumer(AsyncWebsocketConsumer):
-    intra_id_list: list[str] = list()
+    nickname_list: list[str] = list()
     wait_list: Deque["GeneralGameWaitConsumer"] = deque()
 
     def __init__(self, *args, **kwargs):
@@ -76,9 +76,9 @@ class GeneralGameWaitConsumer(AsyncWebsocketConsumer):
         if self.user.is_authenticated:
             if (
                 self in GeneralGameWaitConsumer.wait_list
-                and self.user.intra_id in GeneralGameWaitConsumer.intra_id_list
+                and self.user.nickname in GeneralGameWaitConsumer.nickname_list
             ):
-                GeneralGameWaitConsumer.intra_id_list.remove(self.user.intra_id)
+                GeneralGameWaitConsumer.nickname_list.remove(self.user.nickname)
                 GeneralGameWaitConsumer.wait_list.remove(self)
 
     @classmethod
@@ -88,18 +88,18 @@ class GeneralGameWaitConsumer(AsyncWebsocketConsumer):
         player2 = GeneralGameWaitConsumer.wait_list.popleft()
         await player1.send(json.dumps({"game_id": game_id}))
         await player2.send(json.dumps({"game_id": game_id}))
-        GeneralGameWaitConsumer.intra_id_list.remove(player1.user.intra_id)
-        GeneralGameWaitConsumer.intra_id_list.remove(player2.user.intra_id)
+        GeneralGameWaitConsumer.nickname_list.remove(player1.user.nickname)
+        GeneralGameWaitConsumer.nickname_list.remove(player2.user.nickname)
         ACTIVE_GENERAL_GAMES[game_id] = GeneralGame(
             Player(1, player1.user.intra_id, player1.user.nickname),
             Player(2, player2.user.intra_id, player2.user.nickname),
         )
 
     async def add_wait_list(self) -> bool:
-        if self.user.intra_id in GeneralGameWaitConsumer.intra_id_list:
+        if self.user.nickname in GeneralGameWaitConsumer.nickname_list:
             return False
         GeneralGameWaitConsumer.wait_list.append(self)
-        GeneralGameWaitConsumer.intra_id_list.append(self.user.intra_id)
+        GeneralGameWaitConsumer.nickname_list.append(self.user.nickname)
         return True
 
 
@@ -314,7 +314,9 @@ class TournamentGameWaitConsumer(AsyncWebsocketConsumer):
             self.isProcessingComplete = True
             # TODO test 필요
             ACTIVE_TOURNAMENTS[tournament_name] = Tournament(
-                tournament_name=tournament_name, create_user_intra_id=self.user.intra_id
+                tournament_name=tournament_name,
+                create_user_intra_id=self.user.intra_id,
+                create_user_nickname=self.user.nickname,
             )
 
         await self.send(
@@ -360,7 +362,7 @@ class TournamentGameConsumer(AsyncWebsocketConsumer):
             await self.accept()
             player_number, wait_detail_json = (
                 self.tournament.build_tournament_wait_detail_json(
-                    intra_id=self.user.intra_id
+                    intra_id=self.user.intra_id, nickname=self.user.nickname
                 )
             )
             if int(player_number[-1]) <= TOURNAMENT_PLAYER_MAX_CNT // 2:
@@ -391,14 +393,14 @@ class TournamentGameConsumer(AsyncWebsocketConsumer):
             self.group_name_a,
             {
                 "type": "send.message",
-                "message": self.tournament.disconnect_tournament(self.user.intra_id),
+                "message": self.tournament.disconnect_tournament(self.user.nickname),
             },
         )
         await self.channel_layer.group_send(
             self.group_name_b,
             {
                 "type": "send.message",
-                "message": self.tournament.disconnect_tournament(self.user.intra_id),
+                "message": self.tournament.disconnect_tournament(self.user.nickname),
             },
         )
         if self.tournament.get_player_total_cnt() == 0:
@@ -408,12 +410,12 @@ class TournamentGameConsumer(AsyncWebsocketConsumer):
         data = json.loads(text_data)
         if data.get("message_type") == MessageType.WAIT.value:
             number = data.get("number")
-            intra_id = data.get("intra_id")
-            if intra_id != self.user.intra_id:
+            nickname = data.get("nickname")
+            if nickname != self.user.nickname:
                 return
 
             if not self.tournament.try_set_ready(
-                player_number=number, intra_id=intra_id
+                player_number=number, nickname=nickname
             ):
                 return
 
@@ -462,7 +464,7 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
         end_message = event["end_message"]
 
         # Send message to WebSocket
-        if self.user.intra_id == self.round.get_winner():
+        if self.user.nickname == self.round.get_winner():
             await self.send(text_data=stay_message)
         else:
             await self.send(text_data=end_message)
@@ -514,7 +516,7 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
         # 게임이 비정상 종료 되었을 때
         if self.round.get_status() != GameStatus.END:
             self.tournament.set_status(TournamentStatus.ERROR)
-            data = self.round.build_error_json(self.user.intra_id)
+            data = self.round.build_error_json(self.user.nickname)
             await self.channel_layer.group_send(
                 self.tournament_broadcast,
                 {"type": "game.message", "message": data},
@@ -564,9 +566,9 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
 
                 if self.tournament.is_all_round_ready():
                     if self.round_number != int(RoundNumber.FINAL_NUMBER.value):
-                        player1_intra_id, player2_intra_id = self.tournament.get_round(
+                        player1_nickname, player2_nickname = self.tournament.get_round(
                             1
-                        ).get_intra_ids()
+                        ).get_nicknames()
                         await self.channel_layer.group_send(
                             hashlib.md5(
                                 (self.tournament_name + "_" + "1").encode("utf-8")
@@ -577,15 +579,15 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
                                     {
                                         "message_type": MessageType.START.value,
                                         "round": "1",
-                                        "1p": player1_intra_id,
-                                        "2p": player2_intra_id,
+                                        "1p": player1_nickname,
+                                        "2p": player2_nickname,
                                     }
                                 ),
                             },
                         )
-                        player3_intra_id, player4_intra_id = self.tournament.get_round(
+                        player3_nickname, player4_nickname = self.tournament.get_round(
                             2
-                        ).get_intra_ids()
+                        ).get_nicknames()
                         await self.channel_layer.group_send(
                             hashlib.md5(
                                 (self.tournament_name + "_" + "2").encode("utf-8")
@@ -596,8 +598,8 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
                                     {
                                         "message_type": MessageType.START.value,
                                         "round": "2",
-                                        "1p": player3_intra_id,
-                                        "2p": player4_intra_id,
+                                        "1p": player3_nickname,
+                                        "2p": player4_nickname,
                                     }
                                 ),
                             },
@@ -611,9 +613,9 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
                         self.tournament.set_status(status=TournamentStatus.PLAYING)
 
                     else:
-                        player1_intra_id, player2_intra_id = self.tournament.get_round(
+                        player1_nickname, player2_nickname = self.tournament.get_round(
                             3
-                        ).get_intra_ids()
+                        ).get_nicknames()
                         await self.channel_layer.group_send(
                             hashlib.md5(
                                 (self.tournament_name + "_" + "3").encode("utf-8")
@@ -624,8 +626,8 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
                                     {
                                         "message_type": MessageType.START.value,
                                         "round": "3",
-                                        "1p": player1_intra_id,
-                                        "2p": player2_intra_id,
+                                        "1p": player1_nickname,
+                                        "2p": player2_nickname,
                                     }
                                 ),
                             },

--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -197,21 +197,9 @@ class GeneralGameConsumer(AsyncWebsocketConsumer):
                         game.get_db_data(), winner_id, loser_id
                     )
                     self.db_complete = True
-                    await self.send(
-                        json.dumps(
-                            {
-                                "message_type": MessageType.COMPLETE.value,
-                            }
-                        )
-                    )
+                    await self.send(game.build_complete_json())
             except ValidationError:
-                await self.send(
-                    json.dumps(
-                        {
-                            "message_type": MessageType.ERROR.value,
-                        }
-                    )
-                )
+                await self.send(game.build_complete_json(is_error=True))
 
     async def wait_ball(self, game: GeneralGame) -> None:
         cnt = 0
@@ -721,9 +709,7 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
                     (
                         {
                             "type": "game.message",
-                            "message": json.dumps(
-                                {"message_type": MessageType.COMPLETE.value}
-                            ),
+                            "message": self.tournament.build_tournament_complete_json(),
                         }
                     ),
                 )
@@ -733,8 +719,8 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
                     (
                         {
                             "type": "game.message",
-                            "message": json.dumps(
-                                {"message_type": MessageType.ERROR.value}
+                            "message": self.tournament.build_tournament_complete_json(
+                                is_error=True
                             ),
                         }
                     ),

--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -273,20 +273,19 @@ class TournamentGameWaitConsumer(AsyncWebsocketConsumer):
             return True
         return False
 
+    @staticmethod
+    def _get_wait_list() -> list[dict[str, str]]:
+        wait_list = []
+        for t in ACTIVE_TOURNAMENTS.values():
+            if t.get_status() == TournamentStatus.WAIT and t.get_player_total_cnt() < 4:
+                wait_list.append(t.build_tournament_wait_dict())
+        return wait_list
+
     async def connect(self) -> None:
         self.user = self.scope["user"]
         if self.user.is_authenticated:
             await self.accept()
-            await self.send(
-                json.dumps(
-                    {
-                        "game_list": [
-                            t.build_tournament_wait_dict()
-                            for t in ACTIVE_TOURNAMENTS.values()
-                        ]
-                    }
-                )
-            )
+            await self.send(json.dumps({"game_list": self._get_wait_list()}))
         else:
             await self.close()
 

--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -91,7 +91,8 @@ class GeneralGameWaitConsumer(AsyncWebsocketConsumer):
         GeneralGameWaitConsumer.intra_id_list.remove(player1.user.intra_id)
         GeneralGameWaitConsumer.intra_id_list.remove(player2.user.intra_id)
         ACTIVE_GENERAL_GAMES[game_id] = GeneralGame(
-            Player(1, player1.user.intra_id), Player(2, player2.user.intra_id)
+            Player(1, player1.user.intra_id, player1.user.nickname),
+            Player(2, player2.user.intra_id, player2.user.nickname),
         )
 
     async def add_wait_list(self) -> bool:

--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -128,7 +128,7 @@ class GeneralGameConsumer(AsyncWebsocketConsumer):
             self.game_group_name = f"game_{self.game_id}"
             await self.channel_layer.group_add(self.game_group_name, self.channel_name)
             await self.accept()
-            await self.send(GeneralGame.build_ready_json(number, player.intra_id))
+            await self.send(GeneralGame.build_ready_json(number, player.nickname))
         else:
             await self.close()
 
@@ -139,7 +139,7 @@ class GeneralGameConsumer(AsyncWebsocketConsumer):
                 ACTIVE_GENERAL_GAMES.pop(self.game_id)
                 if game.get_status() != GameStatus.END:  # 게임 중간에 나갔을 경우
                     game.set_status(GameStatus.ERROR)
-                    data = game.build_error_json(self.user.intra_id)
+                    data = game.build_error_json(self.user.nickname)
                     await self.channel_layer.group_send(
                         self.game_group_name, {"type": "game.message", "message": data}
                     )

--- a/back/pong_game/module/GeneralGame.py
+++ b/back/pong_game/module/GeneralGame.py
@@ -90,9 +90,10 @@ class GeneralGame:
             }
         )
 
-    def build_game_json(self) -> json:
+    def build_game_json(self, game_start: bool = True) -> json:
         self._move_paddle()
-        self._move_ball()
+        if game_start:
+            self._move_ball()
         paddle1 = self.player1.get_paddle().get_position_x()
         paddle2 = self.player2.get_paddle().get_position_x()
         ball_x, ball_y, ball_z = self.ball.get_position()

--- a/back/pong_game/module/GeneralGame.py
+++ b/back/pong_game/module/GeneralGame.py
@@ -72,12 +72,12 @@ class GeneralGame:
             self.player2.paddle_handler(data["input"])
 
     @staticmethod
-    def build_ready_json(number: int, intra_id: str) -> json:
+    def build_ready_json(number: int, nickname: str) -> json:
         return json.dumps(
             {
                 "message_type": MessageType.READY.value,
                 "number": "player1" if number == 1 else "player2",
-                "intra_id": intra_id,
+                "intra_id": nickname,
             }
         )
 
@@ -85,8 +85,8 @@ class GeneralGame:
         return json.dumps(
             {
                 "message_type": MessageType.START.value,
-                "1p": self.player1.get_intra_id(),
-                "2p": self.player2.get_intra_id(),
+                "1p": self.player1.get_nickname(),
+                "2p": self.player2.get_nickname(),
             }
         )
 
@@ -128,12 +128,12 @@ class GeneralGame:
             }
         )
 
-    def build_error_json(self, intra_id: str) -> json:
+    def build_error_json(self, nickname: str) -> json:
         self.status = GameStatus.END
         return json.dumps(
             {
                 "message_type": MessageType.ERROR.value,
-                "intra_id": intra_id,
+                "intra_id": nickname,
             }
         )
 

--- a/back/pong_game/module/GeneralGame.py
+++ b/back/pong_game/module/GeneralGame.py
@@ -138,6 +138,17 @@ class GeneralGame:
             }
         )
 
+    def build_complete_json(self, is_error=False) -> json:
+        return json.dumps(
+            {
+                "message_type": (
+                    MessageType.ERROR.value if is_error else MessageType.COMPLETE.value
+                ),
+                "player1": self.player1.get_nickname(),
+                "player2": self.player2.get_nickname(),
+            }
+        )
+
     def _move_paddle(self) -> None:
         self.player1.get_paddle().move_handler(player_num=1)
         self.player2.get_paddle().move_handler(player_num=2)

--- a/back/pong_game/module/GeneralGame.py
+++ b/back/pong_game/module/GeneralGame.py
@@ -77,7 +77,7 @@ class GeneralGame:
             {
                 "message_type": MessageType.READY.value,
                 "number": "player1" if number == 1 else "player2",
-                "intra_id": nickname,
+                "nickname": nickname,
             }
         )
 
@@ -133,7 +133,7 @@ class GeneralGame:
         return json.dumps(
             {
                 "message_type": MessageType.ERROR.value,
-                "intra_id": nickname,
+                "nickname": nickname,
             }
         )
 
@@ -207,13 +207,13 @@ class GeneralGame:
         else:
             return None, None
 
-    def set_player(self, player_intra_id: str) -> None:
+    def set_player(self, player_intra_id: str, player_nickname: str) -> None:
         if self.player1 is None:
-            self.player1 = Player(1, player_intra_id)
+            self.player1 = Player(1, player_intra_id, player_nickname)
             return
 
         if self.player2 is None:
-            self.player2 = Player(2, player_intra_id)
+            self.player2 = Player(2, player_intra_id, player_nickname)
             return
 
     def set_ready(self, number: str) -> None:

--- a/back/pong_game/module/Player.py
+++ b/back/pong_game/module/Player.py
@@ -3,9 +3,10 @@ from .GameSetValue import PlayerStatus
 
 
 class Player:
-    def __init__(self, number: int, intra_id: str):
+    def __init__(self, number: int, intra_id: str, nickname: str = None):
         self.number: int = number
         self.intra_id: str = intra_id
+        self.nickname: str = nickname if nickname else intra_id
         self.status: PlayerStatus = PlayerStatus.WAIT
         self.paddle: Paddle = Paddle(number)
 
@@ -14,6 +15,9 @@ class Player:
 
     def get_intra_id(self) -> str:
         return self.intra_id
+
+    def get_nickname(self) -> str:
+        return self.nickname
 
     def get_status(self) -> PlayerStatus:
         return self.status

--- a/back/pong_game/module/Round.py
+++ b/back/pong_game/module/Round.py
@@ -23,14 +23,14 @@ class Round(GeneralGame):
 
     def build_end_json(self) -> json:
         self.winner = (
-            self.player1.get_intra_id()
+            self.player1.get_nickname()
             if self.score1 > self.score2
-            else self.player2.get_intra_id()
+            else self.player2.get_nickname()
         )
         self.loser = (
-            self.player2.get_intra_id()
+            self.player2.get_nickname()
             if self.score1 > self.score2
-            else self.player1.get_intra_id()
+            else self.player1.get_nickname()
         )
         return json.dumps(
             {
@@ -43,14 +43,14 @@ class Round(GeneralGame):
 
     def build_stay_json(self) -> json:
         self.winner = (
-            self.player1.get_intra_id()
+            self.player1.get_nickname()
             if self.score1 > self.score2
-            else self.player2.get_intra_id()
+            else self.player2.get_nickname()
         )
         self.loser = (
-            self.player2.get_intra_id()
+            self.player2.get_nickname()
             if self.score1 > self.score2
-            else self.player1.get_intra_id()
+            else self.player1.get_nickname()
         )
         return json.dumps(
             {
@@ -75,8 +75,8 @@ class Round(GeneralGame):
     def get_winner(self) -> str:
         return self.winner
 
-    def get_intra_ids(self) -> tuple[str, str]:
-        return self.player1.get_intra_id(), self.player2.get_intra_id()
+    def get_nicknames(self) -> tuple[str, str]:
+        return self.player1.get_nickname(), self.player2.get_nickname()
 
     def get_is_closed(self) -> bool:
         return self.is_closed

--- a/back/pong_game/module/Round.py
+++ b/back/pong_game/module/Round.py
@@ -75,6 +75,9 @@ class Round(GeneralGame):
     def get_winner(self) -> str:
         return self.winner
 
+    def get_intra_ids(self) -> tuple[str, str]:
+        return self.player1.get_intra_id(), self.player2.get_intra_id()
+
     def get_is_closed(self) -> bool:
         return self.is_closed
 

--- a/back/pong_game/module/Tournament.py
+++ b/back/pong_game/module/Tournament.py
@@ -32,6 +32,7 @@ class Tournament:
             None,
             None,
         ]
+        self.nickname_list: list[str] = ["", "", "", ""]
         self.player_total_cnt: int = 1
         self.status: TournamentStatus = TournamentStatus.WAIT
 
@@ -122,6 +123,19 @@ class Tournament:
                 }
             )
 
+    def build_tournament_complete_json(self, is_error=False) -> json:
+        return json.dumps(
+            {
+                "message_type": (
+                    MessageType.ERROR.value if is_error else MessageType.COMPLETE.value
+                ),
+                "player1": self.nickname_list[0],
+                "player2": self.nickname_list[1],
+                "player3": self.nickname_list[2],
+                "player4": self.nickname_list[3],
+            }
+        )
+
     def disconnect_tournament(self, nickname: str) -> json:
         data = {"message_type": MessageType.WAIT.value}
         for idx, player in enumerate(self.player_list):
@@ -139,7 +153,7 @@ class Tournament:
                 return False
             if player.get_status() != PlayerStatus.READY:
                 return False
-
+        self.nickname_list = [player.get_nickname() for player in self.player_list]
         return True
 
     def is_all_round_ready(self):

--- a/back/pong_game/module/Tournament.py
+++ b/back/pong_game/module/Tournament.py
@@ -16,11 +16,18 @@ from .Round import Round
 
 
 class Tournament:
-    def __init__(self, tournament_name: str, create_user_intra_id: str):
+    def __init__(
+        self,
+        tournament_name: str,
+        create_user_intra_id: str,
+        create_user_nickname: str,
+    ):
         self.tournament_name: str = tournament_name
         self.round_list: list[Round or None] = [None, None, None]
         self.player_list: list[Player or None] = [
-            Player(number=1, intra_id=create_user_intra_id),
+            Player(
+                number=1, intra_id=create_user_intra_id, nickname=create_user_nickname
+            ),
             None,
             None,
             None,
@@ -34,11 +41,13 @@ class Tournament:
             "wait_num": str(self.player_total_cnt),
         }
 
-    def _join_tournament_with_intra_id(self, intra_id: str) -> PlayerNumber:
+    def _join_tournament_with_intra_id(
+        self, intra_id: str, nickname: str
+    ) -> PlayerNumber:
         for idx, player in enumerate(self.player_list):
             if player is None:
                 self.player_list[idx] = Player(
-                    number=2 if idx % 2 else 1, intra_id=intra_id
+                    number=2 if idx % 2 else 1, intra_id=intra_id, nickname=nickname
                 )
                 self.player_total_cnt += 1
                 if self.player_total_cnt == TOURNAMENT_PLAYER_MAX_CNT:
@@ -47,12 +56,16 @@ class Tournament:
             elif player.get_intra_id() == intra_id:
                 return PlayerNumber.PLAYER_1
 
-    def build_tournament_wait_detail_json(self, intra_id: str) -> tuple[str, json]:
-        player_number = self._join_tournament_with_intra_id(intra_id=intra_id).value
+    def build_tournament_wait_detail_json(
+        self, intra_id: str, nickname: str
+    ) -> tuple[str, json]:
+        player_number = self._join_tournament_with_intra_id(
+            intra_id=intra_id, nickname=nickname
+        ).value
         return player_number, json.dumps(
             {
                 "message_type": MessageType.WAIT.value,
-                "intra_id": intra_id,
+                "nickname": nickname,
                 "total": self.player_total_cnt,
                 "number": player_number,
             }
@@ -61,8 +74,8 @@ class Tournament:
     def build_tournament_ready_json(
         self,
         team_name: TournamentGroupName,
-        player1_intra_id: str = None,
-        player2_intra_id: str = None,
+        player1_nickname: str = None,
+        player2_nickname: str = None,
     ) -> json:
         if team_name == TournamentGroupName.A_TEAM:
             self.round_list[0] = Round(
@@ -72,8 +85,8 @@ class Tournament:
                 {
                     "message_type": MessageType.READY.value,
                     "round": RoundNumber.ROUND_1.value,
-                    "1p": self.player_list[0].get_intra_id(),
-                    "2p": self.player_list[1].get_intra_id(),
+                    "1p": self.player_list[0].get_nickname(),
+                    "2p": self.player_list[1].get_nickname(),
                 }
             )
         elif team_name == TournamentGroupName.B_TEAM:
@@ -84,16 +97,16 @@ class Tournament:
                 {
                     "message_type": MessageType.READY.value,
                     "round": RoundNumber.ROUND_2.value,
-                    "1p": self.player_list[2].get_intra_id(),
-                    "2p": self.player_list[3].get_intra_id(),
+                    "1p": self.player_list[2].get_nickname(),
+                    "2p": self.player_list[3].get_nickname(),
                 }
             )
         elif team_name == TournamentGroupName.FINAL_TEAM:
             player1, player2 = None, None
             for idx, player in enumerate(self.player_list):
-                if player.get_intra_id() == player1_intra_id:
+                if player.get_nickname() == player1_nickname:
                     player1 = player
-                elif player.get_intra_id() == player2_intra_id:
+                elif player.get_nickname() == player2_nickname:
                     player2 = player
             player1.set_status(PlayerStatus.READY)
             player2.set_status(PlayerStatus.READY)
@@ -104,18 +117,18 @@ class Tournament:
                 {
                     "message_type": MessageType.READY.value,
                     "round": RoundNumber.ROUND_3.value,
-                    "1p": player1_intra_id,
-                    "2p": player2_intra_id,
+                    "1p": player1_nickname,
+                    "2p": player2_nickname,
                 }
             )
 
-    def disconnect_tournament(self, intra_id: str) -> json:
+    def disconnect_tournament(self, nickname: str) -> json:
         data = {"message_type": MessageType.WAIT.value}
         for idx, player in enumerate(self.player_list):
-            if player is not None and player.get_intra_id() == intra_id:
+            if player is not None and player.get_nickname() == nickname:
                 self.player_list[idx] = None
                 self.player_total_cnt -= 1
-                data["intra_id"] = intra_id
+                data["nickname"] = nickname
                 data["total"] = self.player_total_cnt
                 data["number"] = list(PlayerNumber)[idx].value
         return json.dumps(data)
@@ -156,12 +169,12 @@ class Tournament:
     def set_status(self, status: TournamentStatus) -> None:
         self.status = status
 
-    def try_set_ready(self, player_number: str, intra_id: str) -> bool:
+    def try_set_ready(self, player_number: str, nickname: str) -> bool:
         player_numbers = [player.value for player in PlayerNumber]
         idx = player_numbers.index(player_number)
         if (
             self.player_list[idx] is None
-            or self.player_list[idx].get_intra_id() != intra_id
+            or self.player_list[idx].get_nickname() != nickname
         ):
             return False
         self.player_list[idx].set_status(PlayerStatus.READY)

--- a/back/pong_game/tests.py
+++ b/back/pong_game/tests.py
@@ -165,8 +165,12 @@ class GeneralGameConsumerTests(TestCase):
         start 전까지 환경 세팅
         """
 
-        self.user1 = await self.create_test_user(intra_id="test1")
-        self.user2 = await self.create_test_user(intra_id="test2")
+        self.user1 = await self.create_test_user(
+            intra_id="test1", nickname="test1_nickname"
+        )
+        self.user2 = await self.create_test_user(
+            intra_id="test2", nickname="test2_nickname"
+        )
         # 대기방 입장 및 게임 id 생성
         communicator1 = WebsocketCommunicator(application, "/ws/general_game/wait/")
         communicator1.scope["user"] = self.user1
@@ -208,7 +212,7 @@ class GeneralGameConsumerTests(TestCase):
             text_data=json.dumps(
                 {
                     "message_type": "ready",
-                    "intra_id": "test1",
+                    "nickname": "test1_nickname",
                     "number": "player1",
                 }
             )
@@ -218,7 +222,7 @@ class GeneralGameConsumerTests(TestCase):
             text_data=json.dumps(
                 {
                     "message_type": "ready",
-                    "intra_id": "test2",
+                    "nickname": "test2_nickname",
                     "number": "player2",
                 }
             )
@@ -249,7 +253,9 @@ class GeneralGameConsumerTests(TestCase):
         self.user1 = await self.create_test_user(
             intra_id="test3", nickname="test3_nickname"
         )
-        self.user2 = await self.create_test_user(intra_id="test4")
+        self.user2 = await self.create_test_user(
+            intra_id="test4", nickname="test4_nickname"
+        )
 
         # 대기방 입장 및 게임 id 생성
         communicator1 = WebsocketCommunicator(application, "/ws/general_game/wait/")
@@ -282,7 +288,7 @@ class GeneralGameConsumerTests(TestCase):
         user1_response = await communicator1.receive_from()
         user1_response_dict = json.loads(user1_response)
         self.assertEqual(user1_response_dict["message_type"], "ready")
-        self.assertEqual(user1_response_dict["intra_id"], self.user1.nickname)
+        self.assertEqual(user1_response_dict["nickname"], self.user1.nickname)
         self.assertEqual(user1_response_dict["number"], "player1")
 
         communicator2 = WebsocketCommunicator(
@@ -298,7 +304,7 @@ class GeneralGameConsumerTests(TestCase):
         user2_response = await communicator2.receive_from()
         user2_response_dict = json.loads(user2_response)
         self.assertEqual(user2_response_dict["message_type"], "ready")
-        self.assertEqual(user2_response_dict["intra_id"], self.user2.nickname)
+        self.assertEqual(user2_response_dict["nickname"], self.user2.nickname)
         self.assertEqual(user2_response_dict["number"], "player2")
 
         # user1,2 응답
@@ -490,11 +496,13 @@ class TournamentGameWaitConsumerTests(TestCase):
         {
             "tournament_name": "test_tournament1",
             "create_user_intra_id": "test_intra_id1",
+            "create_user_nickname": "test_nickname1",
             "wait_num": "1",
         },
         {
             "tournament_name": "test_tournament2",
             "create_user_intra_id": "test_intra_id2",
+            "create_user_nickname": "test_nickname2",
             "wait_num": "1",
         },
     ]
@@ -505,8 +513,12 @@ class TournamentGameWaitConsumerTests(TestCase):
         TournamentGameLogs.objects.create(
             tournament_name=tournament_name,
             round=1,
-            player1=get_user_model().objects.create_user(intra_id="default1"),
-            player2=get_user_model().objects.create_user(intra_id="default2"),
+            player1=get_user_model().objects.create_user(
+                intra_id="default1", nickname="default1_nickname"
+            ),
+            player2=get_user_model().objects.create_user(
+                intra_id="default2", nickname="default2_nickname"
+            ),
             player1_score=5,
             player2_score=0,
             start_time=timezone.now() - datetime.timedelta(hours=5),
@@ -515,9 +527,11 @@ class TournamentGameWaitConsumerTests(TestCase):
         )
 
     @database_sync_to_async
-    def create_test_user(self, intra_id):
+    def create_test_user(self, intra_id, nickname):
         # 테스트 사용자 생성
-        return get_user_model().objects.create_user(intra_id=intra_id)
+        return get_user_model().objects.create_user(
+            intra_id=intra_id, nickname=nickname
+        )
 
     @database_sync_to_async
     def delete_test_user(self, user):
@@ -532,6 +546,7 @@ class TournamentGameWaitConsumerTests(TestCase):
             tournament_info["tournament_name"]: Tournament(
                 tournament_name=tournament_info["tournament_name"],
                 create_user_intra_id=tournament_info["create_user_intra_id"],
+                create_user_nickname=tournament_info["create_user_nickname"],
             )
             for tournament_info in self.TEST_TOURNAMENTS_INFO
         }
@@ -570,7 +585,9 @@ class TournamentGameWaitConsumerTests(TestCase):
         현재 존재하는 토너먼트 방을 잘 받아오는지 테스트
         """
 
-        self.user1 = await self.create_test_user(intra_id="test1")
+        self.user1 = await self.create_test_user(
+            intra_id="test1", nickname="test1_nickname"
+        )
         communicator1 = WebsocketCommunicator(application, "/ws/tournament_game/wait/")
         communicator1.scope["user"] = self.user1
         connected, _ = await communicator1.connect()
@@ -598,7 +615,9 @@ class TournamentGameWaitConsumerTests(TestCase):
         토너먼트 네임을 consumer에게 보냈을때 성공 또는 실패를 클라이언트에게 잘 보내는지 테스트
         """
 
-        self.user1 = await self.create_test_user(intra_id="test1")
+        self.user1 = await self.create_test_user(
+            intra_id="test1", nickname="test1_nickname"
+        )
         communicator1 = WebsocketCommunicator(application, "/ws/tournament_game/wait/")
         communicator1.scope["user"] = self.user1
         connected, _ = await communicator1.connect()
@@ -698,11 +717,13 @@ class TournamentGameConsumerTests(TestCase):
         {
             "tournament_name": "test_tournament1",
             "create_user_intra_id": "room_1_owner",
+            "create_user_nickname": "room_1_owner_nickname",
             "wait_num": "1",
         },
         {
             "tournament_name": "test_tournament2",
             "create_user_intra_id": "room_2_owner",
+            "create_user_nickname": "room_2_owner_nickname",
             "wait_num": "1",
         },
     ]
@@ -719,11 +740,14 @@ class TournamentGameConsumerTests(TestCase):
         self.room_2_user1_id = "room_2_user1"
         self.room_2_user2_id = "room_2_user2"
         self.room_2_user3_id = "room_2_user3"
+        self.suffix = "_nickname"
 
     @database_sync_to_async
-    def create_test_user(self, intra_id):
+    def create_test_user(self, intra_id, nickname):
         # 테스트 사용자 생성
-        return get_user_model().objects.create_user(intra_id=intra_id)
+        return get_user_model().objects.create_user(
+            intra_id=intra_id, nickname=nickname
+        )
 
     @database_sync_to_async
     def delete_test_user(self, user):
@@ -743,6 +767,7 @@ class TournamentGameConsumerTests(TestCase):
             tournament_info["tournament_name"]: Tournament(
                 tournament_name=tournament_info["tournament_name"],
                 create_user_intra_id=tournament_info["create_user_intra_id"],
+                create_user_nickname=tournament_info["create_user_nickname"],
             )
             for tournament_info in self.TEST_TOURNAMENTS_INFO
         }
@@ -787,13 +812,16 @@ class TournamentGameConsumerTests(TestCase):
         communicators = []
         total_num = 1
         for user_info in users_info:
-            user = await self.create_test_user(intra_id=user_info["intra_id"])
+            user = await self.create_test_user(
+                intra_id=user_info["intra_id"],
+                nickname=user_info["intra_id"] + self.suffix,
+            )
             communicator, response_dict = await self.connect_and_echo_data(
                 tournament_name=tournament_name, user=user
             )
 
             self.assertEqual(response_dict["message_type"], MessageType.WAIT.value)
-            self.assertEqual(response_dict["intra_id"], user.intra_id)
+            self.assertEqual(response_dict["nickname"], user.nickname)
             self.assertEqual(response_dict["total"], total_num)
             self.assertEqual(
                 response_dict["number"], user_info["expected_player_number"].value
@@ -833,38 +861,38 @@ class TournamentGameConsumerTests(TestCase):
     async def test_receive_wait_ready_data(self):
         users_info_test_tournament1 = [
             {
-                "intra_id": self.room_1_owner_id,
+                "nickname": self.room_1_owner_id + self.suffix,
                 "expected_player_number": PlayerNumber.PLAYER_1,
             },
             {
-                "intra_id": self.room_1_user1_id,
+                "nickname": self.room_1_user1_id + self.suffix,
                 "expected_player_number": PlayerNumber.PLAYER_2,
             },
             {
-                "intra_id": self.room_1_user2_id,
+                "nickname": self.room_1_user2_id + self.suffix,
                 "expected_player_number": PlayerNumber.PLAYER_3,
             },
             {
-                "intra_id": self.room_1_user3_id,
+                "nickname": self.room_1_user3_id + self.suffix,
                 "expected_player_number": PlayerNumber.PLAYER_4,
             },
         ]
 
         users_info_test_tournament2 = [
             {
-                "intra_id": self.room_2_owner_id,
+                "nickname": self.room_2_owner_id + self.suffix,
                 "expected_player_number": PlayerNumber.PLAYER_1,
             },
             {
-                "intra_id": self.room_2_user1_id,
+                "nickname": self.room_2_user1_id + self.suffix,
                 "expected_player_number": PlayerNumber.PLAYER_2,
             },
             {
-                "intra_id": self.room_2_user2_id,
+                "nickname": self.room_2_user2_id + self.suffix,
                 "expected_player_number": PlayerNumber.PLAYER_3,
             },
             {
-                "intra_id": self.room_2_user3_id,
+                "nickname": self.room_2_user3_id + self.suffix,
                 "expected_player_number": PlayerNumber.PLAYER_4,
             },
         ]
@@ -884,46 +912,46 @@ class TournamentGameConsumerTests(TestCase):
         users_ready_info_test_tournament1 = [
             {
                 "round": "1",
-                "1p": self.room_1_owner_id,
-                "2p": self.room_1_user1_id,
+                "1p": self.room_1_owner_id + self.suffix,
+                "2p": self.room_1_user1_id + self.suffix,
             },
             {
                 "round": "1",
-                "1p": self.room_1_owner_id,
-                "2p": self.room_1_user1_id,
+                "1p": self.room_1_owner_id + self.suffix,
+                "2p": self.room_1_user1_id + self.suffix,
             },
             {
                 "round": "2",
-                "1p": self.room_1_user2_id,
-                "2p": self.room_1_user3_id,
+                "1p": self.room_1_user2_id + self.suffix,
+                "2p": self.room_1_user3_id + self.suffix,
             },
             {
                 "round": "2",
-                "1p": self.room_1_user2_id,
-                "2p": self.room_1_user3_id,
+                "1p": self.room_1_user2_id + self.suffix,
+                "2p": self.room_1_user3_id + self.suffix,
             },
         ]
 
         users_ready_info_test_tournament2 = [
             {
                 "round": "1",
-                "1p": self.room_2_owner_id,
-                "2p": self.room_2_user1_id,
+                "1p": self.room_2_owner_id + self.suffix,
+                "2p": self.room_2_user1_id + self.suffix,
             },
             {
                 "round": "1",
-                "1p": self.room_2_owner_id,
-                "2p": self.room_2_user1_id,
+                "1p": self.room_2_owner_id + self.suffix,
+                "2p": self.room_2_user1_id + self.suffix,
             },
             {
                 "round": "2",
-                "1p": self.room_2_user2_id,
-                "2p": self.room_2_user3_id,
+                "1p": self.room_2_user2_id + self.suffix,
+                "2p": self.room_2_user3_id + self.suffix,
             },
             {
                 "round": "2",
-                "1p": self.room_2_user2_id,
-                "2p": self.room_2_user3_id,
+                "1p": self.room_2_user2_id + self.suffix,
+                "2p": self.room_2_user3_id + self.suffix,
             },
         ]
 
@@ -1027,7 +1055,10 @@ class TournamentGameConsumerTests(TestCase):
         # room1에 세번째 유저 참가
         communicator, response_dict = await self.connect_and_echo_data(
             tournament_name=self.room_1_name,
-            user=await self.create_test_user(intra_id=self.room_1_user2_id),
+            user=await self.create_test_user(
+                intra_id=self.room_1_user2_id,
+                nickname=self.room_1_user2_id + self.suffix,
+            ),
         )
 
         # 남는 메세지 버리기
@@ -1075,7 +1106,9 @@ class TournamentGameConsumerTests(TestCase):
         communicator = WebsocketCommunicator(
             application, f"/ws/tournament_game/{self.room_1_name}/"
         )
-        user = await self.create_test_user(intra_id="other_user")
+        user = await self.create_test_user(
+            intra_id="other_user", nickname="other_user" + self.suffix
+        )
         communicator.scope["user"] = user
         connected, _ = await communicator.connect()
         tournament = ACTIVE_TOURNAMENTS.get(self.room_1_name)
@@ -1090,11 +1123,13 @@ class TournamentGameRoundConsumerTests(TestCase):
         {
             "tournament_name": "한글",
             "create_user_intra_id": "room_1_owner",
+            "create_user_nickname": "room_1_owner_nickname",
             "wait_num": "1",
         },
         {
             "tournament_name": "test_tournament2",
             "create_user_intra_id": "room_2_owner",
+            "create_user_nickname": "room_2_owner_nickname",
             "wait_num": "1",
         },
     ]
@@ -1111,11 +1146,14 @@ class TournamentGameRoundConsumerTests(TestCase):
         self.room_2_user1_id = "room_2_user1"
         self.room_2_user2_id = "room_2_user2"
         self.room_2_user3_id = "room_2_user3"
+        self.suffix = "_nickname"
 
     @database_sync_to_async
     def create_test_user(self, intra_id):
         # 테스트 사용자 생성
-        return get_user_model().objects.create_user(intra_id=intra_id)
+        return get_user_model().objects.create_user(
+            intra_id=intra_id, nickname=intra_id + self.suffix
+        )
 
     @database_sync_to_async
     def delete_test_user(self, user):
@@ -1159,6 +1197,7 @@ class TournamentGameRoundConsumerTests(TestCase):
             tournament_info["tournament_name"]: Tournament(
                 tournament_name=tournament_info["tournament_name"],
                 create_user_intra_id=tournament_info["create_user_intra_id"],
+                create_user_nickname=tournament_info["create_user_nickname"],
             )
             for tournament_info in self.TEST_TOURNAMENTS_INFO
         }
@@ -1224,7 +1263,7 @@ class TournamentGameRoundConsumerTests(TestCase):
             )
 
             self.assertEqual(response_dict["message_type"], MessageType.WAIT.value)
-            self.assertEqual(response_dict["intra_id"], user.intra_id)
+            self.assertEqual(response_dict["nickname"], user.nickname)
             self.assertEqual(response_dict["total"], total_num)
             self.assertEqual(
                 response_dict["number"], user_info["expected_player_number"].value
@@ -1293,26 +1332,26 @@ class TournamentGameRoundConsumerTests(TestCase):
             {
                 "message_type": MessageType.READY.value,
                 "round": "1",
-                "1p": self.room_1_owner_id,
-                "2p": self.room_1_user1_id,
+                "1p": self.room_1_owner_id + self.suffix,
+                "2p": self.room_1_user1_id + self.suffix,
             },
             {
                 "message_type": MessageType.READY.value,
                 "round": "1",
-                "1p": self.room_1_owner_id,
-                "2p": self.room_1_user1_id,
+                "1p": self.room_1_owner_id + self.suffix,
+                "2p": self.room_1_user1_id + self.suffix,
             },
             {
                 "message_type": MessageType.READY.value,
                 "round": "2",
-                "1p": self.room_1_user2_id,
-                "2p": self.room_1_user3_id,
+                "1p": self.room_1_user2_id + self.suffix,
+                "2p": self.room_1_user3_id + self.suffix,
             },
             {
                 "message_type": MessageType.READY.value,
                 "round": "2",
-                "1p": self.room_1_user2_id,
-                "2p": self.room_1_user3_id,
+                "1p": self.room_1_user2_id + self.suffix,
+                "2p": self.room_1_user3_id + self.suffix,
             },
         ]
 
@@ -1350,26 +1389,26 @@ class TournamentGameRoundConsumerTests(TestCase):
         start_reponse_dict = json.loads(start_reponse)
         self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
         self.assertEqual(start_reponse_dict["round"], "1")
-        self.assertEqual(start_reponse_dict["1p"], self.room_1_owner_id)
-        self.assertEqual(start_reponse_dict["2p"], self.room_1_user1_id)
+        self.assertEqual(start_reponse_dict["1p"], self.room_1_owner_id + self.suffix)
+        self.assertEqual(start_reponse_dict["2p"], self.room_1_user1_id + self.suffix)
         start_reponse = await self.test_tournament1_communicators[1].receive_from()
         start_reponse_dict = json.loads(start_reponse)
         self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
         self.assertEqual(start_reponse_dict["round"], "1")
-        self.assertEqual(start_reponse_dict["1p"], self.room_1_owner_id)
-        self.assertEqual(start_reponse_dict["2p"], self.room_1_user1_id)
+        self.assertEqual(start_reponse_dict["1p"], self.room_1_owner_id + self.suffix)
+        self.assertEqual(start_reponse_dict["2p"], self.room_1_user1_id + self.suffix)
         start_reponse = await self.test_tournament1_communicators[2].receive_from()
         start_reponse_dict = json.loads(start_reponse)
         self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
         self.assertEqual(start_reponse_dict["round"], "2")
-        self.assertEqual(start_reponse_dict["1p"], self.room_1_user2_id)
-        self.assertEqual(start_reponse_dict["2p"], self.room_1_user3_id)
+        self.assertEqual(start_reponse_dict["1p"], self.room_1_user2_id + self.suffix)
+        self.assertEqual(start_reponse_dict["2p"], self.room_1_user3_id + self.suffix)
         start_reponse = await self.test_tournament1_communicators[3].receive_from()
         start_reponse_dict = json.loads(start_reponse)
         self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
         self.assertEqual(start_reponse_dict["round"], "2")
-        self.assertEqual(start_reponse_dict["1p"], self.room_1_user2_id)
-        self.assertEqual(start_reponse_dict["2p"], self.room_1_user3_id)
+        self.assertEqual(start_reponse_dict["1p"], self.room_1_user2_id + self.suffix)
+        self.assertEqual(start_reponse_dict["2p"], self.room_1_user3_id + self.suffix)
 
         await self.test_tournament1_communicators[0].send_to(
             text_data=json.dumps(
@@ -1426,8 +1465,8 @@ class TournamentGameRoundConsumerTests(TestCase):
                 {
                     "message_type": "stay",
                     "round": "1",
-                    "winner": "room_1_user1",
-                    "loser": "room_1_owner",
+                    "winner": "room_1_user1" + self.suffix,
+                    "loser": "room_1_owner" + self.suffix,
                 }
             )
         )
@@ -1437,8 +1476,8 @@ class TournamentGameRoundConsumerTests(TestCase):
                 {
                     "message_type": "stay",
                     "round": "2",
-                    "winner": "room_1_user3",
-                    "loser": "room_1_user2",
+                    "winner": "room_1_user3" + self.suffix,
+                    "loser": "room_1_user2" + self.suffix,
                 }
             )
         )
@@ -1458,8 +1497,8 @@ class TournamentGameRoundConsumerTests(TestCase):
                 ready_data={
                     "message_type": MessageType.READY.value,
                     "round": "3",
-                    "1p": self.room_1_user1_id,
-                    "2p": self.room_1_user3_id,
+                    "1p": self.room_1_user1_id + self.suffix,
+                    "2p": self.room_1_user3_id + self.suffix,
                 },
             )
         )
@@ -1472,8 +1511,8 @@ class TournamentGameRoundConsumerTests(TestCase):
                 ready_data={
                     "message_type": MessageType.READY.value,
                     "round": "3",
-                    "1p": self.room_1_user1_id,
-                    "2p": self.room_1_user3_id,
+                    "1p": self.room_1_user1_id + self.suffix,
+                    "2p": self.room_1_user3_id + self.suffix,
                 },
             )
         )
@@ -1511,8 +1550,8 @@ class TournamentGameRoundConsumerTests(TestCase):
                 {
                     "message_type": "stay",
                     "round": "3",
-                    "winner": "room_1_user3",
-                    "loser": "room_1_user1",
+                    "winner": "room_1_user3" + self.suffix,
+                    "loser": "room_1_user1" + self.suffix,
                 }
             )
         )
@@ -1591,26 +1630,26 @@ class TournamentGameRoundConsumerTests(TestCase):
             {
                 "message_type": MessageType.READY.value,
                 "round": "1",
-                "1p": self.room_1_owner_id,
-                "2p": self.room_1_user1_id,
+                "1p": self.room_1_owner_id + self.suffix,
+                "2p": self.room_1_user1_id + self.suffix,
             },
             {
                 "message_type": MessageType.READY.value,
                 "round": "1",
-                "1p": self.room_1_owner_id,
-                "2p": self.room_1_user1_id,
+                "1p": self.room_1_owner_id + self.suffix,
+                "2p": self.room_1_user1_id + self.suffix,
             },
             {
                 "message_type": MessageType.READY.value,
                 "round": "2",
-                "1p": self.room_1_user2_id,
-                "2p": self.room_1_user3_id,
+                "1p": self.room_1_user2_id + self.suffix,
+                "2p": self.room_1_user3_id + self.suffix,
             },
             {
                 "message_type": MessageType.READY.value,
                 "round": "2",
-                "1p": self.room_1_user2_id,
-                "2p": self.room_1_user3_id,
+                "1p": self.room_1_user2_id + self.suffix,
+                "2p": self.room_1_user3_id + self.suffix,
             },
         ]
         # 1221
@@ -1618,26 +1657,26 @@ class TournamentGameRoundConsumerTests(TestCase):
             {
                 "message_type": MessageType.READY.value,
                 "round": "1",
-                "1p": self.room_1_owner_id,
-                "2p": self.room_1_user1_id,
+                "1p": self.room_1_owner_id + self.suffix,
+                "2p": self.room_1_user1_id + self.suffix,
             },
             {
                 "message_type": MessageType.READY.value,
                 "round": "2",
-                "1p": self.room_1_user2_id,
-                "2p": self.room_1_user3_id,
+                "1p": self.room_1_user2_id + self.suffix,
+                "2p": self.room_1_user3_id + self.suffix,
             },
             {
                 "message_type": MessageType.READY.value,
                 "round": "2",
-                "1p": self.room_1_user2_id,
-                "2p": self.room_1_user3_id,
+                "1p": self.room_1_user2_id + self.suffix,
+                "2p": self.room_1_user3_id + self.suffix,
             },
             {
                 "message_type": MessageType.READY.value,
                 "round": "1",
-                "1p": self.room_1_owner_id,
-                "2p": self.room_1_user1_id,
+                "1p": self.room_1_owner_id + self.suffix,
+                "2p": self.room_1_user1_id + self.suffix,
             },
         ]
         await self.check_recieved_ready_messgae_valid(
@@ -1741,8 +1780,8 @@ class TournamentGameRoundConsumerTests(TestCase):
                 {
                     "message_type": "stay",
                     "round": "1",
-                    "winner": "room_1_user1",
-                    "loser": "room_1_owner",
+                    "winner": "room_1_user1" + self.suffix,
+                    "loser": "room_1_owner" + self.suffix,
                 }
             )
         )
@@ -1752,8 +1791,8 @@ class TournamentGameRoundConsumerTests(TestCase):
                 {
                     "message_type": "stay",
                     "round": "2",
-                    "winner": "room_1_user3",
-                    "loser": "room_1_user2",
+                    "winner": "room_1_user3" + self.suffix,
+                    "loser": "room_1_user2" + self.suffix,
                 }
             )
         )
@@ -1773,8 +1812,8 @@ class TournamentGameRoundConsumerTests(TestCase):
                 ready_data={
                     "message_type": MessageType.READY.value,
                     "round": "3",
-                    "1p": self.room_1_user1_id,
-                    "2p": self.room_1_user3_id,
+                    "1p": self.room_1_user1_id + self.suffix,
+                    "2p": self.room_1_user3_id + self.suffix,
                 },
             )
         )
@@ -1787,8 +1826,8 @@ class TournamentGameRoundConsumerTests(TestCase):
                 ready_data={
                     "message_type": MessageType.READY.value,
                     "round": "3",
-                    "1p": self.room_1_user1_id,
-                    "2p": self.room_1_user3_id,
+                    "1p": self.room_1_user1_id + self.suffix,
+                    "2p": self.room_1_user3_id + self.suffix,
                 },
             )
         )
@@ -1826,8 +1865,8 @@ class TournamentGameRoundConsumerTests(TestCase):
                 {
                     "message_type": "stay",
                     "round": "3",
-                    "winner": "room_1_user3",
-                    "loser": "room_1_user1",
+                    "winner": "room_1_user3" + self.suffix,
+                    "loser": "room_1_user1" + self.suffix,
                 }
             )
         )
@@ -1887,26 +1926,26 @@ class TournamentGameRoundConsumerTests(TestCase):
             {
                 "message_type": MessageType.READY.value,
                 "round": "1",
-                "1p": self.room_1_owner_id,
-                "2p": self.room_1_user1_id,
+                "1p": self.room_1_owner_id + self.suffix,
+                "2p": self.room_1_user1_id + self.suffix,
             },
             {
                 "message_type": MessageType.READY.value,
                 "round": "1",
-                "1p": self.room_1_owner_id,
-                "2p": self.room_1_user1_id,
+                "1p": self.room_1_owner_id + self.suffix,
+                "2p": self.room_1_user1_id + self.suffix,
             },
             {
                 "message_type": MessageType.READY.value,
                 "round": "2",
-                "1p": self.room_1_user2_id,
-                "2p": self.room_1_user3_id,
+                "1p": self.room_1_user2_id + self.suffix,
+                "2p": self.room_1_user3_id + self.suffix,
             },
             {
                 "message_type": MessageType.READY.value,
                 "round": "2",
-                "1p": self.room_1_user2_id,
-                "2p": self.room_1_user3_id,
+                "1p": self.room_1_user2_id + self.suffix,
+                "2p": self.room_1_user3_id + self.suffix,
             },
         ]
 
@@ -1944,18 +1983,26 @@ class TournamentGameRoundConsumerTests(TestCase):
         start_reponse_dict = json.loads(start_reponse)
         self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
         self.assertEqual(start_reponse_dict["round"], "1")
+        self.assertEqual(start_reponse_dict["1p"], self.room_1_owner_id + self.suffix)
+        self.assertEqual(start_reponse_dict["2p"], self.room_1_user1_id + self.suffix)
         start_reponse = await self.test_tournament1_communicators[1].receive_from()
         start_reponse_dict = json.loads(start_reponse)
         self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
         self.assertEqual(start_reponse_dict["round"], "1")
+        self.assertEqual(start_reponse_dict["1p"], self.room_1_owner_id + self.suffix)
+        self.assertEqual(start_reponse_dict["2p"], self.room_1_user1_id + self.suffix)
         start_reponse = await self.test_tournament1_communicators[2].receive_from()
         start_reponse_dict = json.loads(start_reponse)
         self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
         self.assertEqual(start_reponse_dict["round"], "2")
+        self.assertEqual(start_reponse_dict["1p"], self.room_1_user2_id + self.suffix)
+        self.assertEqual(start_reponse_dict["2p"], self.room_1_user3_id + self.suffix)
         start_reponse = await self.test_tournament1_communicators[3].receive_from()
         start_reponse_dict = json.loads(start_reponse)
         self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
         self.assertEqual(start_reponse_dict["round"], "2")
+        self.assertEqual(start_reponse_dict["1p"], self.room_1_user2_id + self.suffix)
+        self.assertEqual(start_reponse_dict["2p"], self.room_1_user3_id + self.suffix)
 
         await self.test_tournament1_communicators[0].send_to(
             text_data=json.dumps(
@@ -2024,26 +2071,26 @@ class TournamentGameRoundConsumerTests(TestCase):
             {
                 "message_type": MessageType.READY.value,
                 "round": "1",
-                "1p": self.room_1_owner_id,
-                "2p": self.room_1_user1_id,
+                "1p": self.room_1_owner_id + self.suffix,
+                "2p": self.room_1_user1_id + self.suffix,
             },
             {
                 "message_type": MessageType.READY.value,
                 "round": "1",
-                "1p": self.room_1_owner_id,
-                "2p": self.room_1_user1_id,
+                "1p": self.room_1_owner_id + self.suffix,
+                "2p": self.room_1_user1_id + self.suffix,
             },
             {
                 "message_type": MessageType.READY.value,
                 "round": "2",
-                "1p": self.room_1_user2_id,
-                "2p": self.room_1_user3_id,
+                "1p": self.room_1_user2_id + self.suffix,
+                "2p": self.room_1_user3_id + self.suffix,
             },
             {
                 "message_type": MessageType.READY.value,
                 "round": "2",
-                "1p": self.room_1_user2_id,
-                "2p": self.room_1_user3_id,
+                "1p": self.room_1_user2_id + self.suffix,
+                "2p": self.room_1_user3_id + self.suffix,
             },
         ]
 
@@ -2149,8 +2196,8 @@ class TournamentGameRoundConsumerTests(TestCase):
                 {
                     "message_type": "stay",
                     "round": "1",
-                    "winner": "room_1_user1",
-                    "loser": "room_1_owner",
+                    "winner": "room_1_user1" + self.suffix,
+                    "loser": "room_1_owner" + self.suffix,
                 }
             )
         )
@@ -2160,8 +2207,8 @@ class TournamentGameRoundConsumerTests(TestCase):
                 {
                     "message_type": "stay",
                     "round": "2",
-                    "winner": "room_1_user3",
-                    "loser": "room_1_user2",
+                    "winner": "room_1_user3" + self.suffix,
+                    "loser": "room_1_user2" + self.suffix,
                 }
             )
         )
@@ -2181,8 +2228,8 @@ class TournamentGameRoundConsumerTests(TestCase):
                 ready_data={
                     "message_type": MessageType.READY.value,
                     "round": "3",
-                    "1p": self.room_1_user1_id,
-                    "2p": self.room_1_user3_id,
+                    "1p": self.room_1_user1_id + self.suffix,
+                    "2p": self.room_1_user3_id + self.suffix,
                 },
             )
         )
@@ -2195,8 +2242,8 @@ class TournamentGameRoundConsumerTests(TestCase):
                 ready_data={
                     "message_type": MessageType.READY.value,
                     "round": "3",
-                    "1p": self.room_1_user1_id,
-                    "2p": self.room_1_user3_id,
+                    "1p": self.room_1_user1_id + self.suffix,
+                    "2p": self.room_1_user3_id + self.suffix,
                 },
             )
         )

--- a/back/pong_game/tests.py
+++ b/back/pong_game/tests.py
@@ -375,6 +375,8 @@ class GeneralGameConsumerTests(TestCase):
         user2_response = await communicator2.receive_from()
         user2_dict = json.loads(user2_response)
         self.assertEqual(user2_dict["message_type"], MessageType.COMPLETE.value)
+        self.assertEqual(user2_dict["player1"], "test1_nickname")
+        self.assertEqual(user2_dict["player2"], "test2_nickname")
 
         # db 저장 될 때 까지 0.2초씩 기다림 timeout은 2초
         game_data_from_db = await self.wait_for_game_data(
@@ -1560,6 +1562,16 @@ class TournamentGameRoundConsumerTests(TestCase):
         await self.wait_for_tournament_data(tournamnet_name=self.room_1_name, round=1)
         await self.wait_for_tournament_data(tournamnet_name=self.room_1_name, round=2)
         await self.wait_for_tournament_data(tournamnet_name=self.room_1_name, round=3)
+
+        user2_response = await self.test_tournament1_communicators[1].receive_from()
+        user2_dict = json.loads(user2_response)
+
+        self.assertEqual(user2_dict["message_type"], "complete")
+        self.assertEqual(user2_dict["player1"], "room_1_owner_nickname")
+        self.assertEqual(user2_dict["player2"], "room_1_user1_nickname")
+        self.assertEqual(user2_dict["player3"], "room_1_user2_nickname")
+        self.assertEqual(user2_dict["player4"], "room_1_user3_nickname")
+
         await self.discard_all_message(self.test_tournament1_communicators)
 
         # user db에 잘 저장 됐는지 확인하는 테스트

--- a/back/pong_game/tests.py
+++ b/back/pong_game/tests.py
@@ -559,7 +559,7 @@ class TournamentGameWaitConsumerTests(TestCase):
         response = await communicator.receive_from()
         return json.loads(response)
 
-    async def test_receive_active_tournamnet_data(self):
+    async def test_receive_active_tournament_data(self):
         """
         현재 존재하는 토너먼트 방을 잘 받아오는지 테스트
         """
@@ -1344,18 +1344,26 @@ class TournamentGameRoundConsumerTests(TestCase):
         start_reponse_dict = json.loads(start_reponse)
         self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
         self.assertEqual(start_reponse_dict["round"], "1")
+        self.assertEqual(start_reponse_dict["1p"], self.room_1_owner_id)
+        self.assertEqual(start_reponse_dict["2p"], self.room_1_user1_id)
         start_reponse = await self.test_tournament1_communicators[1].receive_from()
         start_reponse_dict = json.loads(start_reponse)
         self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
         self.assertEqual(start_reponse_dict["round"], "1")
+        self.assertEqual(start_reponse_dict["1p"], self.room_1_owner_id)
+        self.assertEqual(start_reponse_dict["2p"], self.room_1_user1_id)
         start_reponse = await self.test_tournament1_communicators[2].receive_from()
         start_reponse_dict = json.loads(start_reponse)
         self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
         self.assertEqual(start_reponse_dict["round"], "2")
+        self.assertEqual(start_reponse_dict["1p"], self.room_1_user2_id)
+        self.assertEqual(start_reponse_dict["2p"], self.room_1_user3_id)
         start_reponse = await self.test_tournament1_communicators[3].receive_from()
         start_reponse_dict = json.loads(start_reponse)
         self.assertEqual(start_reponse_dict["message_type"], MessageType.START.value)
         self.assertEqual(start_reponse_dict["round"], "2")
+        self.assertEqual(start_reponse_dict["1p"], self.room_1_user2_id)
+        self.assertEqual(start_reponse_dict["2p"], self.room_1_user3_id)
 
         await self.test_tournament1_communicators[0].send_to(
             text_data=json.dumps(

--- a/docs/general_game_socket.md
+++ b/docs/general_game_socket.md
@@ -27,7 +27,7 @@
 ```json
 {
   "message_type": "ready",
-  "intra_id": "{intra_id}",
+  "nickname": "{nickname}",
   "number": "{player1 / player2}"
 }
 ```
@@ -37,7 +37,7 @@
 ```json
 {
   "message_type": "ready",
-  "intra_id": "{intra_id}",
+  "nickname": "{nickname}",
   "number": "{player1 / player2}"
 }
 ```
@@ -49,8 +49,8 @@
 ```json
 {
   "message_type": "start",
-  "1p": "{intra_id}",
-  "2p": "{intra_id}"
+  "1p": "{nickname}",
+  "2p": "{nickname}"
 }
 ```
 
@@ -99,7 +99,7 @@
 ```json
 {
     "message_type": "error",
-    "intra_id": "{접속 종료한 intra_id}"
+    "nickname": "{접속 종료한 nickname}"
 }
 ```
 

--- a/docs/tournament_game_socket.md
+++ b/docs/tournament_game_socket.md
@@ -56,13 +56,13 @@
 ### 6. [Back] 클라이언트에게 wait 전송
 
 - 대기방 인원 전체에게 발송
-- 프론트가 저장하고 있는 intra_id 값이 기본값이면 intra_id와 number 저장
+- 프론트가 저장하고 있는 nickname 값이 기본값이면 nickname와 number 저장
 - 이후에는 total만 갱신하면서 대기 중인 인원 표시
 
 ```json
 {
   "message_type": "wait",
-  "intra_id": "{intra_id}",
+  "nickname": "{nickname}",
   "total": "{join_player_num}",
   "number": "{player1 / player2 / player3 / player4}"
 }
@@ -73,7 +73,7 @@
 ```json
 {
   "message_type": "wait",
-  "intra_id": "{intra_id}",
+  "nickname": "{nickname}",
   "total": "{join_player_num}",
   "number": "{player1 / player2 / player3 / player4}"
 }
@@ -86,7 +86,7 @@
 ```json
 {
     "message_type": "wait",
-    "intra_id": "{접속 종료한 intra_id}",
+    "nickname": "{접속 종료한 nickname}",
     "total": "{join_player_num}",
     "number": "{player1 / player2 / player3 / player4}"
 }
@@ -98,8 +98,8 @@
 {
   "message_type": "ready",
   "round": "{1 / 2}",
-  "1p": "{intra_id}",
-  "2p": "{intra_id}"
+  "1p": "{nickname}",
+  "2p": "{nickname}"
 }
 ```
 
@@ -111,8 +111,8 @@
 {
   "message_type": "ready",
   "round": "{1 / 2 / 3}",
-  "1p": "{intra_id}",
-  "2p": "{intra_id}"
+  "1p": "{nickname}",
+  "2p": "{nickname}"
 }
 ```
 
@@ -124,8 +124,8 @@
 {
   "message_type": "start",
   "round": "{1 / 2 / 3}",
-  "1p": "{intra_id}",
-  "2p": "{intra_id}" 
+  "1p": "{nickname}",
+  "2p": "{nickname}" 
 }
 ```
 
@@ -164,7 +164,7 @@
 ```json
 {
     "message_type": "error",
-    "intra_id": "{접속 종료한 intra_id}"
+    "nickname": "{접속 종료한 nickname}"
 }
 ```
 
@@ -216,8 +216,8 @@
 {
   "message_type": "ready",
   "round": "3",
-  "1p": "{intra_id}",
-  "2p": "{intra_id}"
+  "1p": "{nickname}",
+  "2p": "{nickname}"
 }
 ```
 
@@ -231,8 +231,8 @@
 {
   "message_type": "ready",
   "round": "3",
-  "1p": "{intra_id}",
-  "2p": "{intra_id}"
+  "1p": "{nickname}",
+  "2p": "{nickname}"
 }
 ```
 

--- a/docs/tournament_game_socket.md
+++ b/docs/tournament_game_socket.md
@@ -123,7 +123,9 @@
 ```json
 {
   "message_type": "start",
-  "round": "{1 / 2 / 3}"
+  "round": "{1 / 2 / 3}",
+  "1p": "{intra_id}",
+  "2p": "{intra_id}" 
 }
 ```
 


### PR DESCRIPTION
### Summary

- 일반 게임이 끝났을 때, 두 플레이어 모두 db에 저장해서 로그가 중복되는 현상 수정
- 진행중인 게임과 인원이 꽉 찬 게임은 wait_list에서 제외해서 보내주도록 수정
- 토너먼트 start 메시지에 1p, 2p 추가
- 프론트에 보내주는 메시지에서 intra_id -> nickname으로 수정
- 게임이 시작할 때와 득점했을 때, 2초동안 공이 움직이지 않도록 수정
- db complete 메시지에 게임에 참석한 인원 내용도 같이 전송하도록 수정
- test 모드에선 모든 host를 허용하도록 수정


### Describe

#### 1. 일반 게임 로그가 두 번 생기는 현상 수정

- 현재 양쪽 플레이어에게 모두 end 메시지를 받고 db에 저장하는 로직을 수행합니다. 이에 db에 두 번 저장합니다.
- 이를 방지하기 위해 승자의 intra_id만 db 저장 로직을 수행하도록 변경했습니다.
- 또한 승자가 여러번 저장 요청하는 것을 방지하기 위해 `db_complete` 라는 boolean 값을 추가했습니다.


#### 2. wait_list 목록 수정

- 프론트에서 이미 진행 중인 게임과 인원이 꽉 찬 게임을 제거해달라는 요청을 수용했습니다.
- `_get_wait_list()` 함수를 만들어서 관련된 로직을 수행하도록 만들었습니다.


#### 3. start 메시지에 1p, 2p 정보 추가

- 프론트 요청에 따라 토너먼트 start 메시지에 1p, 2p를 추가했습니다.


#### 4. intra_id -> nickname

- intra_id는 불변하고 nickname만 변경이 가능합니다. 그래서 표시해야 할 이름도 intra_id가 아니라 nickname이 맞다고 판단했습니다.
- 프론트와 합의 후, 필드명도 nickname으로 변경하고 보내는 값들도 nickname으로 변경했습니다.


#### 5. 시작과 득점 시, 2초 동안 공 정지

- 프론트 요청에 따라 공이 2초 간 정지되는 로직을 추가했습니다.
- 페이지에 게임 화면은 그려져야 하기에 공이 정지된 값을 2초간 보내주는 `wait_ball` 함수를 추가했습니다.
- 프론트와 합의 후, 패들 움직임은 허용하도록 만들었습니다.


#### 6. db 저장 완료 메시지에 참가한 전체 인원 목록 추가

- 프론트 요청에 따라 db 저장 완료 시, 메시지에 참가한 전체 인원을 같이 보내도록 변경했습니다.
- 토너먼트는 `nickname_list` 변수를 추가해서 토너먼트가 시작할 때 저장되도록 수정했습니다.


#### 7. test 모드에선 모든 host 허용

- debug 모드를 제거하면서 `ALLOWED_HOST` 를 `BASE_IP` 만 허용하게 만들었습니다.
- 하지만 test는 `BASE_IP` 가 아니기에 에러가 났습니다. 따라서 test에 한해서 `ALLOWED_HOST` 를 전체로 수정했습니다.


### TODO

- 자체 테스트로 확인은 했지만 프론트와 합쳐서 수정된 목록을 다 확인해 봐야 합니다.
