### PR TITLE
[Back-65] solve TODO

### DIFF
--- a/back/accounts/views.py
+++ b/back/accounts/views.py
@@ -191,9 +191,12 @@ class CallbackAPIView(APIView):
             headers={"Authorization": f"Bearer {access_token}"},
         )
         coalition_info = coalition_info_request.json()
-        login_id = user_info["login"]
-        image_address = user_info["image"]["versions"]["large"]
-        house = HOUSE[coalition_info[0]["name"]]
+        try:
+            login_id = user_info["login"]
+            image_address = user_info["image"]["versions"]["large"]
+            house = HOUSE[coalition_info[0]["name"]]
+        except:
+            return redirect(BASE_FULL_IP)
         user_instance, created = Users.objects.get_or_create(
             intra_id=login_id, defaults={"nickname": login_id, "house": house}
         )
@@ -320,7 +323,7 @@ class ChartViewSet(viewsets.ModelViewSet):
         return Response(data)
 
 
-# TODO test 용도 삭제 해야함
+# test 유저용 login
 class TestAccountLogin(APIView):
 
     def get(self, request, *args, **kwargs) -> redirect or Response:

--- a/back/accounts/views.py
+++ b/back/accounts/views.py
@@ -35,30 +35,33 @@ class UsersViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
     queryset = Users.objects.all()
     serializer_class: UsersSerializer = UsersSerializer
-    http_method_names = ["get", "post"]  # TODO debug를 위해 post 임시 추가
+    http_method_names = ["get"]
 
-    def create(self, request, *args, **kwargs) -> Response:
-        """
-        디버그용 post
-        """
-        intra_id: str | None = request.data.get("intra_id")
-        if not intra_id:
-            return Response(
-                {"error": "intra_id is required"}, status=status.HTTP_400_BAD_REQUEST
-            )
-
-        # intra_id 중복 검사
-        if Users.objects.filter(intra_id=intra_id).exists():
-            return Response(
-                {"error": "User with this intra_id already exists"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        # 새로운 사용자 생성
-        user = Users.objects.create_user(intra_id=intra_id)
-        serializer = self.get_serializer(user)
-
-        return Response(serializer.data, status=status.HTTP_201_CREATED)
+    # debug용 post
+    # http_method_names = ["get", "post"]
+    #
+    # def create(self, request, *args, **kwargs) -> Response:
+    #     """
+    #     디버그용 post
+    #     """
+    #     intra_id: str | None = request.data.get("intra_id")
+    #     if not intra_id:
+    #         return Response(
+    #             {"error": "intra_id is required"}, status=status.HTTP_400_BAD_REQUEST
+    #         )
+    #
+    #     # intra_id 중복 검사
+    #     if Users.objects.filter(intra_id=intra_id).exists():
+    #         return Response(
+    #             {"error": "User with this intra_id already exists"},
+    #             status=status.HTTP_400_BAD_REQUEST,
+    #         )
+    #
+    #     # 새로운 사용자 생성
+    #     user = Users.objects.create_user(intra_id=intra_id)
+    #     serializer = self.get_serializer(user)
+    #
+    #     return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
 class MeViewSet(viewsets.ModelViewSet):

--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -316,7 +316,6 @@ class TournamentGameWaitConsumer(AsyncWebsocketConsumer):
         else:
             result = ResultType.SUCCESS.value
             self.isProcessingComplete = True
-            # TODO test 필요
             ACTIVE_TOURNAMENTS[tournament_name] = Tournament(
                 tournament_name=tournament_name,
                 create_user_intra_id=self.user.intra_id,
@@ -344,7 +343,6 @@ class TournamentGameConsumer(AsyncWebsocketConsumer):
         # Send message to WebSocket
         await self.send(text_data=message)
 
-    # TODO accept 위치 테스트 터지면 보기
     async def connect(self) -> None:
         self.user = self.scope["user"]
         if self.user.is_authenticated:
@@ -487,7 +485,6 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
             self.tournament_broadcast = hashlib.md5(
                 (self.tournament_name + "_broadcast").encode("utf-8")
             ).hexdigest()
-            # TODO if 문 간소화 by myko
             if (
                 self.tournament is not None
                 and (
@@ -551,7 +548,6 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
     async def receive(self, text_data: json = None, bytes_data=None) -> None:
         data = json.loads(text_data)
         message_type = data.get("message_type")
-        # TODO if문 간소화 하기
         if (
             message_type == MessageType.READY.value
             and self.tournament.get_status() == TournamentStatus.READY

--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -144,10 +144,10 @@ class GeneralGameConsumer(AsyncWebsocketConsumer):
                     await self.channel_layer.group_send(
                         self.game_group_name, {"type": "game.message", "message": data}
                     )
-                self.game_loop_task.cancel()
                 try:  # cancel() 동작이 끝날 때까지 대기
+                    self.game_loop_task.cancel()
                     await self.game_loop_task
-                except asyncio.CancelledError:
+                except:
                     pass  # task가 이미 취소된 경우
             await self.channel_layer.group_discard(
                 self.game_group_name, self.channel_name
@@ -535,12 +535,11 @@ class TournamentGameRoundConsumer(AsyncWebsocketConsumer):
                 and self.tournament_name in ACTIVE_TOURNAMENTS.keys()
             ):
                 ACTIVE_TOURNAMENTS.pop(self.tournament_name)
-            if self.game_loop_task is not None:
+            try:  # cancel() 동작이 끝날 때까지 대기
                 self.game_loop_task.cancel()
-                try:  # cancel() 동작이 끝날 때까지 대기
-                    await self.game_loop_task
-                except asyncio.CancelledError:
-                    pass  # task가 이미 취소된 경우
+                await self.game_loop_task
+            except:
+                pass  # task가 이미 취소된 경우
         await self.channel_layer.group_discard(
             self.tournament_broadcast, self.channel_name
         )

--- a/makefile
+++ b/makefile
@@ -14,11 +14,11 @@ test:
 	cd ./back/ && python3 manage.py test accounts --settings=back.test_settings
 	cd ./back/ && python3 manage.py test pong_game.tests.GeneralGameConsumerTests.test_save_game_data_to_db --settings=back.test_settings
 	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameRoundConsumerTests.test_disconnect2  --settings=back.test_settings
-#	cd ./back/ && python3 manage.py test pong_game.tests.GeneralGameConsumerTests.test_save_game_data_to_db --settings=back.test_settings
+	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameConsumerTests.test_disconnect_test2 --settings=back.test_settings
+	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameConsumerTests.test_overflow_user_connection_test --settings=back.test_settings
+	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameRoundConsumerTests.test_disconnect --settings=back.test_settings
+	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameRoundConsumerTests.test_disconnect2 --settings=back.test_settings
 #	cd ./back/ && python3 manage.py test  --settings=back.test_settings
-#	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameConsumerTests.test_disconnect_test2 --settings=back.test_settings
-#	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameConsumerTests.test_overflow_user_connection_test --settings=back.test_settings
-#	cd ./back/ && python3 manage.py test pong_game.tests.TournamentGameRoundConsumerTests --settings=back.test_settings
 
 
 


### PR DESCRIPTION
### Summary

- TODO문을 확인 후, 제거했습니다.
- loop task를 종료하는 과정에서 예외처리를 수정했습니다.
- login 관련 예외처리를 수정했습니다.


### Describe

#### TODO문 제거

- 대부분의 TODO문이 동작과 관계없는 것으로 확인했습니다. 그래서 제거했습니다.
- debug용 post는 주석처리만 해서 test가 필요할 때, 다시 사용할 수 있도록 만들었습니다.


#### loop task 예외 처리

- 현재 일반 게임에서 loop task에 대한 예외 처리가 없습니다. 그리고 if문으로 검증하는 것이 비동기에서 위험이 있을 것으로 간주했습니다.
- 이에 try, except문에 추가하는 것으로 예외 처리를 진행했습니다.


#### login 예외 처리

- 만약 다른 42 캠퍼스나 키값이 변경되면 login에서 에러가 발생합니다.
- 그래서 키값을 가져오는 동작에서 try, except으로 묶고 에러가 발생하면 홈페이지로 redirect 시켰습니다.


### TODO

- 현재 `pong_game.tests.TournamentGameRoundConsumerTests.test_disconnect` 에서 에러가 발생했다 안 했다가 합니다. 통합 레포에선 발생하지 않지만 주시 할 필요는 있어 보입니다.
