### PR TITLE
Back 71 combine with submitted

### DIFF
--- a/back/back/settings.py
+++ b/back/back/settings.py
@@ -160,3 +160,10 @@ CHANNEL_LAYERS = {
         },
     },
 }
+
+# 기본 render 방식을 json 방식으로 변경
+REST_FRAMEWORK = {
+    "DEFAULT_RENDERER_CLASSES": [
+        "rest_framework.renderers.JSONRenderer",
+    ]
+}

--- a/back/pong_game/consumers.py
+++ b/back/pong_game/consumers.py
@@ -499,19 +499,20 @@ class TournamentGameConsumer(AsyncWebsocketConsumer):
         if self.tournament.get_status() == TournamentStatus.READY:
             return
 
+        data = self.tournament.disconnect_tournament(self.user.nickname)
         # 나간 인원과 줄어든 현재 인원을 전송
         await self.channel_layer.group_send(
             self.group_name_a,
             {
                 "type": "send.message",
-                "message": self.tournament.disconnect_tournament(self.user.nickname),
+                "message": data,
             },
         )
         await self.channel_layer.group_send(
             self.group_name_b,
             {
                 "type": "send.message",
-                "message": self.tournament.disconnect_tournament(self.user.nickname),
+                "message": data,
             },
         )
         if self.tournament.get_player_total_cnt() == 0:

--- a/back/pong_game/tests.py
+++ b/back/pong_game/tests.py
@@ -730,8 +730,8 @@ class TournamentGameConsumerTests(TestCase):
         },
     ]
 
-    def __init__(self, methodName: str = ...):
-        super().__init__(methodName)
+    def __init__(self, method_name: str = ...):
+        super().__init__(method_name)
         self.room_1_name = "test_tournament1"
         self.room_2_name = "test_tournament2"
         self.room_1_owner_id = "room_1_owner"
@@ -1136,8 +1136,8 @@ class TournamentGameRoundConsumerTests(TestCase):
         },
     ]
 
-    def __init__(self, methodName: str = ...):
-        super().__init__(methodName)
+    def __init__(self, method_name: str = ...):
+        super().__init__(method_name)
         self.room_1_name = "한글"
         self.room_2_name = "test_tournament2"
         self.room_1_owner_id = "room_1_owner"


### PR DESCRIPTION
### Summary

- api의 기본 render 방식으로 json으로 변경했습니다.
- 토너먼트 대기 중, 연결 종료 시 중복 종료되는 동작을 수정했습니다.


### Describe

#### render 방법 수정

- 장고에 설정된 기본 render 방법은 http 방식입니다.
- 이를 42api와 같은 방식인 json 방식으로 수정했습니다.


#### 중복 종료 수정

- 토너먼트 대기 중 나갈 시, `self.tournament.disconnect_tournament(self.user.nickname)` 함수가 두 번 호출됩니다.
- 이때 문제는 `self.tournament.disconnect_tournament(self.user.nickname)` 함수가 전체 인원을 줄이는 동작이 포함되어 있기에 두 명이 나간 것처럼 동작됩니다.
- 이에 data를 한 번 받고 이를 두 그룹에 전송하는 것으로 수정했습니다.
