### PR TITLE
[Back-72] fix oauth state

### DIFF
--- a/back/accounts/views.py
+++ b/back/accounts/views.py
@@ -227,14 +227,12 @@ class CallbackAPIView(APIView):
         client_id = os.environ.get("CLIENT_ID")
         client_secret = os.environ.get("CLIENT_SECRET")
         code = request.GET.get("code")
-        state = request.GET.get("state")
         redirect_uri = os.environ.get("REDIRECT_URI")
         data = {
             "grant_type": grant_type,
             "client_id": client_id,
             "client_secret": client_secret,
             "code": code,
-            "state": state,
             "redirect_uri": redirect_uri,
         }
         token_request = requests.post("https://api.intra.42.fr/oauth/token", data)


### PR DESCRIPTION
### Summary
- 기존의 state 비교하는 코드가 의도대로 동작하지 않았습니다.
- .env에 저장돼있던 state를 사용자마다 로그인 시 생성하도록 수정했습니다.
- access_token 받아올 때 state 삭제했습니다.
### Describe
#### 기존의 state 비교하는 코드가 의도대로 동작하지 않았습니다.
```
if request.session.get(＂state＂) and not request.GET.get(＂state＂) == os.environ.get(＂STATE＂):
```
- 과거에 코드를 수정하던 중 (https://github.com/tail-passengers/backend/commit/e2efaa0c566e34f7cc31e973f6f5d74569b5130e) 세션에 state를 저장하는 코드인 request.session[＂state＂] = state를 삭제했습니다.
- 즉 request.session.get(＂state＂)의 반환 값이 False가 됩니다.
```
not request.GET.get(＂state＂) == os.environ.get(＂STATE＂):
```
- 그래서 state를 검사하는 구문이 실행이 안 됩니다.  
#### .env에 저장돼있던 state를 사용자마다 로그인 시 생성하도록 수정했습니다.
- state는 csrf 공격으로부터 최종 사용자를 보호하기 위해 존재합니다
- Once authorization has been obtained from the end-user, the authorization server redirects the end-users user-agent back to the client with the required  value contained in the "state" parameter. The  value enables the client to verify the validity of the request by matching the  value to the user-agent's authenticated state [rfc6749](https://www.rfc-editor.org/rfc/rfc6749#section-10.12)
- 기존의 코드는 동일한 state를 모든 사용자가 사용했습니다
- 보안 적으로 안 좋다고 생각해서 사용자 각각이 로그인 할 때 랜덤으로 생성하도록 수정했습니다.
#### access_token 받아올 때 state 삭제했습니다.
- state 매개변수는 클라이언트가 요청을 시작할 때 생성되고, 그 후에는 서버 측에서 다시 확인하는 과정에서 사용됩니다.
- 즉 OAuth 인증 코드를 사용하여 로그인 시 토큰을 요청하는 단계에서는 필요 없다고 생각해서 삭제했습니다.
### TODO
- 통합 레포에 올려서 테스트를 해봤습니다. 하지만 관련된 에러가 생길 경우 수정이 필요합니다.
